### PR TITLE
feat: 앱을 통한 로그인 #37

### DIFF
--- a/backend/core/build.gradle
+++ b/backend/core/build.gradle
@@ -22,6 +22,7 @@ jar {
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-security'
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-web'
 
     //flyway

--- a/backend/core/src/main/java/site/timecapsulearchive/core/domain/auth/api/AuthApi.java
+++ b/backend/core/src/main/java/site/timecapsulearchive/core/domain/auth/api/AuthApi.java
@@ -7,7 +7,6 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import org.springframework.http.ResponseEntity;
-import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import site.timecapsulearchive.core.domain.auth.dto.request.SignInRequest;
@@ -16,7 +15,6 @@ import site.timecapsulearchive.core.domain.auth.dto.response.OAuthUrlResponse;
 import site.timecapsulearchive.core.domain.auth.dto.response.TemporaryTokenResponse;
 import site.timecapsulearchive.core.domain.auth.dto.response.TokenResponse;
 
-@Validated
 public interface AuthApi {
 
     @Operation(

--- a/backend/core/src/main/java/site/timecapsulearchive/core/domain/auth/api/AuthApi.java
+++ b/backend/core/src/main/java/site/timecapsulearchive/core/domain/auth/api/AuthApi.java
@@ -10,6 +10,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
+import site.timecapsulearchive.core.domain.auth.dto.request.SignInRequest;
 import site.timecapsulearchive.core.domain.auth.dto.request.TokenReIssueRequest;
 import site.timecapsulearchive.core.domain.auth.dto.response.OAuthUrlResponse;
 import site.timecapsulearchive.core.domain.auth.dto.response.TemporaryTokenResponse;
@@ -104,6 +105,26 @@ public interface AuthApi {
     )
     ResponseEntity<TemporaryTokenResponse> getTemporaryTokenResponseByGoogle();
 
+    @Operation(
+        summary = "다른 소셜 프로바이더의 앱으로 인증한 클라이언트 저장 후 토큰 반환",
+        description = "다른 소셜 프로바이더의 앱으로 인증한 클라이언트의 정보를 저장하고 임시 인증 토큰(1시간)을 반환한다.",
+        tags = {"auth"}
+    )
+    @ApiResponses(value = {
+        @ApiResponse(
+            responseCode = "200",
+            description = "ok",
+            content = @Content(
+                mediaType = "application/json",
+                schema = @Schema(implementation = TemporaryTokenResponse.class)
+            )
+        )
+    })
+    @GetMapping(
+        value = "/sign-in",
+        produces = {"application/json"}
+    )
+    ResponseEntity<TemporaryTokenResponse> signInWithSocialProvider(SignInRequest request);
 
     @Operation(
         summary = "액세스 토큰 재발급",

--- a/backend/core/src/main/java/site/timecapsulearchive/core/domain/auth/api/AuthApi.java
+++ b/backend/core/src/main/java/site/timecapsulearchive/core/domain/auth/api/AuthApi.java
@@ -9,7 +9,7 @@ import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
-import site.timecapsulearchive.core.domain.auth.dto.request.SignInRequest;
+import site.timecapsulearchive.core.domain.auth.dto.request.SignUpRequest;
 import site.timecapsulearchive.core.domain.auth.dto.request.TokenReIssueRequest;
 import site.timecapsulearchive.core.domain.auth.dto.response.OAuthUrlResponse;
 import site.timecapsulearchive.core.domain.auth.dto.response.TemporaryTokenResponse;
@@ -119,10 +119,10 @@ public interface AuthApi {
         )
     })
     @GetMapping(
-        value = "/sign-in",
+        value = "/sign-up",
         produces = {"application/json"}
     )
-    ResponseEntity<TemporaryTokenResponse> signInWithSocialProvider(SignInRequest request);
+    ResponseEntity<TemporaryTokenResponse> signUpWithSocialProvider(SignUpRequest request);
 
     @Operation(
         summary = "액세스 토큰 재발급",

--- a/backend/core/src/main/java/site/timecapsulearchive/core/domain/auth/api/AuthApiController.java
+++ b/backend/core/src/main/java/site/timecapsulearchive/core/domain/auth/api/AuthApiController.java
@@ -6,12 +6,13 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
-import site.timecapsulearchive.core.domain.auth.dto.request.SignInRequest;
+import site.timecapsulearchive.core.domain.auth.dto.request.SignUpRequest;
 import site.timecapsulearchive.core.domain.auth.dto.request.TokenReIssueRequest;
 import site.timecapsulearchive.core.domain.auth.dto.response.OAuthUrlResponse;
 import site.timecapsulearchive.core.domain.auth.dto.response.TemporaryTokenResponse;
 import site.timecapsulearchive.core.domain.auth.dto.response.TokenResponse;
 import site.timecapsulearchive.core.domain.auth.service.TokenService;
+import site.timecapsulearchive.core.domain.member.dto.mapper.MemberMapper;
 import site.timecapsulearchive.core.domain.member.service.MemberService;
 
 @RestController
@@ -21,6 +22,7 @@ public class AuthApiController implements AuthApi {
 
     private final TokenService tokenService;
     private final MemberService memberService;
+    private final MemberMapper memberMapper;
 
     @Override
     public ResponseEntity<OAuthUrlResponse> getOAuth2KakaoUrl() {
@@ -49,9 +51,9 @@ public class AuthApiController implements AuthApi {
     }
 
     @Override
-    public ResponseEntity<TemporaryTokenResponse> signInWithSocialProvider(
-        @Valid @RequestBody final SignInRequest request) {
-        Long id = memberService.createUser(request.toEntity());
+    public ResponseEntity<TemporaryTokenResponse> signUpWithSocialProvider(
+        @RequestBody final SignUpRequest request) {
+        Long id = memberService.createMember(memberMapper.signUpRequestToEntity(request));
 
         return ResponseEntity.ok(tokenService.createTemporaryToken(id));
     }

--- a/backend/core/src/main/java/site/timecapsulearchive/core/domain/auth/api/AuthApiController.java
+++ b/backend/core/src/main/java/site/timecapsulearchive/core/domain/auth/api/AuthApiController.java
@@ -1,5 +1,6 @@
 package site.timecapsulearchive.core.domain.auth.api;
 
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -43,13 +44,13 @@ public class AuthApiController implements AuthApi {
 
     @Override
     public ResponseEntity<TokenResponse> reIssueAccessToken(
-        @RequestBody final TokenReIssueRequest request) {
+        @Valid @RequestBody final TokenReIssueRequest request) {
         return ResponseEntity.ok(tokenService.reIssueToken(request.refreshToken()));
     }
 
     @Override
     public ResponseEntity<TemporaryTokenResponse> signInWithSocialProvider(
-        @RequestBody final SignInRequest request) {
+        @Valid @RequestBody final SignInRequest request) {
         Long id = memberService.createUser(request.toEntity());
 
         return ResponseEntity.ok(tokenService.createTemporaryToken(id));

--- a/backend/core/src/main/java/site/timecapsulearchive/core/domain/auth/api/AuthApiController.java
+++ b/backend/core/src/main/java/site/timecapsulearchive/core/domain/auth/api/AuthApiController.java
@@ -5,11 +5,13 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import site.timecapsulearchive.core.domain.auth.dto.request.SignInRequest;
 import site.timecapsulearchive.core.domain.auth.dto.request.TokenReIssueRequest;
 import site.timecapsulearchive.core.domain.auth.dto.response.OAuthUrlResponse;
 import site.timecapsulearchive.core.domain.auth.dto.response.TemporaryTokenResponse;
 import site.timecapsulearchive.core.domain.auth.dto.response.TokenResponse;
 import site.timecapsulearchive.core.domain.auth.service.TokenService;
+import site.timecapsulearchive.core.domain.member.service.MemberService;
 
 @RestController
 @RequiredArgsConstructor
@@ -17,6 +19,7 @@ import site.timecapsulearchive.core.domain.auth.service.TokenService;
 public class AuthApiController implements AuthApi {
 
     private final TokenService tokenService;
+    private final MemberService memberService;
 
     @Override
     public ResponseEntity<OAuthUrlResponse> getOAuth2KakaoUrl() {
@@ -42,6 +45,14 @@ public class AuthApiController implements AuthApi {
     public ResponseEntity<TokenResponse> reIssueAccessToken(
         @RequestBody final TokenReIssueRequest request) {
         return ResponseEntity.ok(tokenService.reIssueToken(request.refreshToken()));
+    }
+
+    @Override
+    public ResponseEntity<TemporaryTokenResponse> signInWithSocialProvider(
+        @RequestBody final SignInRequest request) {
+        Long id = memberService.createUser(request.toEntity());
+
+        return ResponseEntity.ok(tokenService.createTemporaryToken(id));
     }
 
     @Override

--- a/backend/core/src/main/java/site/timecapsulearchive/core/domain/auth/dto/request/CheckStatusRequest.java
+++ b/backend/core/src/main/java/site/timecapsulearchive/core/domain/auth/dto/request/CheckStatusRequest.java
@@ -1,17 +1,19 @@
 package site.timecapsulearchive.core.domain.auth.dto.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
-import org.springframework.validation.annotation.Validated;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import site.timecapsulearchive.core.domain.auth.entity.SocialType;
 
 @Schema(description = "소셜 프로바이더의 인증 아이디로 회원 인증 상태 체크")
-@Validated
 public record CheckStatusRequest(
 
     @Schema(description = "소셜 프로바이더 인증 아이디")
+    @NotBlank
     String authId,
 
     @Schema(description = "소셜 프로바이더 타입")
+    @NotNull
     SocialType socialType
 ) {
 

--- a/backend/core/src/main/java/site/timecapsulearchive/core/domain/auth/dto/request/CheckStatusRequest.java
+++ b/backend/core/src/main/java/site/timecapsulearchive/core/domain/auth/dto/request/CheckStatusRequest.java
@@ -1,0 +1,18 @@
+package site.timecapsulearchive.core.domain.auth.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import org.springframework.validation.annotation.Validated;
+import site.timecapsulearchive.core.domain.auth.entity.SocialType;
+
+@Schema(description = "소셜 프로바이더의 인증 아이디로 회원 인증 상태 체크")
+@Validated
+public record CheckStatusRequest(
+
+    @Schema(description = "소셜 프로바이더 인증 아이디")
+    String authId,
+
+    @Schema(description = "소셜 프로바이더 타입")
+    SocialType socialType
+) {
+
+}

--- a/backend/core/src/main/java/site/timecapsulearchive/core/domain/auth/dto/request/CheckStatusRequest.java
+++ b/backend/core/src/main/java/site/timecapsulearchive/core/domain/auth/dto/request/CheckStatusRequest.java
@@ -9,11 +9,11 @@ import site.timecapsulearchive.core.domain.auth.entity.SocialType;
 public record CheckStatusRequest(
 
     @Schema(description = "소셜 프로바이더 인증 아이디")
-    @NotBlank
+    @NotBlank(message = "인증 아이디는 필수 입니다.")
     String authId,
 
     @Schema(description = "소셜 프로바이더 타입")
-    @NotNull
+    @NotNull(message = "소셜 프로바이더 타입은 필수입니다.")
     SocialType socialType
 ) {
 

--- a/backend/core/src/main/java/site/timecapsulearchive/core/domain/auth/dto/request/SignInRequest.java
+++ b/backend/core/src/main/java/site/timecapsulearchive/core/domain/auth/dto/request/SignInRequest.java
@@ -1,0 +1,33 @@
+package site.timecapsulearchive.core.domain.auth.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import org.springframework.validation.annotation.Validated;
+import site.timecapsulearchive.core.domain.auth.entity.SocialType;
+import site.timecapsulearchive.core.domain.member.entity.Member;
+
+@Schema(description = "소셜 프로바이더의 인증 아이디로 로그인 요청")
+@Validated
+public record SignInRequest(
+
+    @Schema(description = "소셜 프로바이더 인증 아이디")
+    String authId,
+
+    @Schema(description = "사용자 이메일")
+    String email,
+
+    @Schema(description = "사용자 프로필 url")
+    String profileUrl,
+
+    @Schema(description = "소셜 프로바이더 타입")
+    SocialType socialType
+) {
+
+    public Member toEntity() {
+        return Member.builder()
+            .authId(authId)
+            .email(email)
+            .profileUrl(profileUrl)
+            .socialType(socialType)
+            .build();
+    }
+}

--- a/backend/core/src/main/java/site/timecapsulearchive/core/domain/auth/dto/request/SignInRequest.java
+++ b/backend/core/src/main/java/site/timecapsulearchive/core/domain/auth/dto/request/SignInRequest.java
@@ -1,24 +1,30 @@
 package site.timecapsulearchive.core.domain.auth.dto.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
-import org.springframework.validation.annotation.Validated;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import site.timecapsulearchive.core.domain.auth.entity.SocialType;
 import site.timecapsulearchive.core.domain.member.entity.Member;
 
 @Schema(description = "소셜 프로바이더의 인증 아이디로 로그인 요청")
-@Validated
 public record SignInRequest(
 
     @Schema(description = "소셜 프로바이더 인증 아이디")
+    @NotBlank
     String authId,
 
     @Schema(description = "사용자 이메일")
+    @NotBlank
+    @Email
     String email,
 
     @Schema(description = "사용자 프로필 url")
+    @NotBlank
     String profileUrl,
 
     @Schema(description = "소셜 프로바이더 타입")
+    @NotNull
     SocialType socialType
 ) {
 

--- a/backend/core/src/main/java/site/timecapsulearchive/core/domain/auth/dto/request/SignUpRequest.java
+++ b/backend/core/src/main/java/site/timecapsulearchive/core/domain/auth/dto/request/SignUpRequest.java
@@ -10,20 +10,20 @@ import site.timecapsulearchive.core.domain.auth.entity.SocialType;
 public record SignUpRequest(
 
     @Schema(description = "소셜 프로바이더 인증 아이디")
-    @NotBlank
+    @NotBlank(message = "인증 아이디는 필수입니다.")
     String authId,
 
     @Schema(description = "사용자 이메일")
-    @NotBlank
+    @NotBlank(message = "사용자 이메일은 필수입니다.")
     @Email
     String email,
 
     @Schema(description = "사용자 프로필 url")
-    @NotBlank
+    @NotBlank(message = "사용자 프로필 url은 필수입니다.")
     String profileUrl,
 
     @Schema(description = "소셜 프로바이더 타입")
-    @NotNull
+    @NotNull(message = "소셜 프로바이더 타입은 필수입니다.")
     SocialType socialType
 ) {
 

--- a/backend/core/src/main/java/site/timecapsulearchive/core/domain/auth/dto/request/SignUpRequest.java
+++ b/backend/core/src/main/java/site/timecapsulearchive/core/domain/auth/dto/request/SignUpRequest.java
@@ -5,10 +5,9 @@ import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import site.timecapsulearchive.core.domain.auth.entity.SocialType;
-import site.timecapsulearchive.core.domain.member.entity.Member;
 
 @Schema(description = "소셜 프로바이더의 인증 아이디로 로그인 요청")
-public record SignInRequest(
+public record SignUpRequest(
 
     @Schema(description = "소셜 프로바이더 인증 아이디")
     @NotBlank
@@ -28,12 +27,4 @@ public record SignInRequest(
     SocialType socialType
 ) {
 
-    public Member toEntity() {
-        return Member.builder()
-            .authId(authId)
-            .email(email)
-            .profileUrl(profileUrl)
-            .socialType(socialType)
-            .build();
-    }
 }

--- a/backend/core/src/main/java/site/timecapsulearchive/core/domain/auth/dto/request/TokenReIssueRequest.java
+++ b/backend/core/src/main/java/site/timecapsulearchive/core/domain/auth/dto/request/TokenReIssueRequest.java
@@ -3,7 +3,7 @@ package site.timecapsulearchive.core.domain.auth.dto.request;
 import io.swagger.v3.oas.annotations.media.Schema;
 import org.springframework.validation.annotation.Validated;
 
-@Schema(description = "임시 인증 토큰")
+@Schema(description = "토큰 재발급 요청")
 @Validated
 public record TokenReIssueRequest(
 

--- a/backend/core/src/main/java/site/timecapsulearchive/core/domain/auth/dto/request/TokenReIssueRequest.java
+++ b/backend/core/src/main/java/site/timecapsulearchive/core/domain/auth/dto/request/TokenReIssueRequest.java
@@ -1,13 +1,15 @@
 package site.timecapsulearchive.core.domain.auth.dto.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import org.springframework.validation.annotation.Validated;
 
 @Schema(description = "토큰 재발급 요청")
-@Validated
 public record TokenReIssueRequest(
 
     @Schema(description = "리프레시 토큰")
+    @NotBlank
     String refreshToken
 ) {
 

--- a/backend/core/src/main/java/site/timecapsulearchive/core/domain/auth/dto/request/TokenReIssueRequest.java
+++ b/backend/core/src/main/java/site/timecapsulearchive/core/domain/auth/dto/request/TokenReIssueRequest.java
@@ -9,7 +9,7 @@ import org.springframework.validation.annotation.Validated;
 public record TokenReIssueRequest(
 
     @Schema(description = "리프레시 토큰")
-    @NotBlank
+    @NotBlank(message = "리프레시 토큰은 필수입니다.")
     String refreshToken
 ) {
 

--- a/backend/core/src/main/java/site/timecapsulearchive/core/domain/member/api/MemberApi.java
+++ b/backend/core/src/main/java/site/timecapsulearchive/core/domain/member/api/MemberApi.java
@@ -11,8 +11,10 @@ import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PatchMapping;
+import site.timecapsulearchive.core.domain.auth.dto.request.CheckStatusRequest;
 import site.timecapsulearchive.core.domain.member.dto.reqeust.MemberDetailUpdateRequest;
 import site.timecapsulearchive.core.domain.member.dto.response.MemberDetailResponse;
+import site.timecapsulearchive.core.domain.member.dto.response.MemberStatusResponse;
 
 @Validated
 public interface MemberApi {
@@ -56,4 +58,26 @@ public interface MemberApi {
         consumes = {"multipart/form-data"}
     )
     ResponseEntity<Void> updateMemberById(@ModelAttribute MemberDetailUpdateRequest request);
+
+    @Operation(
+        summary = "다른 OAuth2 프로바이더의 아이디로 앱 내의 유저의 인증 상태를 반환",
+        description = "Google, Kakao 프로바이더가 제공하는 유저 아이디로 앱 내의 인증 상태를 반환한다.",
+        tags = {"member"}
+    )
+    @ApiResponses(value = {
+        @ApiResponse(
+            responseCode = "200",
+            description = "ok",
+            content = @Content(
+                mediaType = "application/json",
+                schema = @Schema(implementation = MemberStatusResponse.class)
+            )
+        )
+    })
+    @GetMapping(
+        value = "/status",
+        produces = {"application/json"}
+    )
+    ResponseEntity<MemberStatusResponse> checkStatus(
+        CheckStatusRequest request);
 }

--- a/backend/core/src/main/java/site/timecapsulearchive/core/domain/member/api/MemberApi.java
+++ b/backend/core/src/main/java/site/timecapsulearchive/core/domain/member/api/MemberApi.java
@@ -7,7 +7,6 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import org.springframework.http.ResponseEntity;
-import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PatchMapping;
@@ -16,7 +15,6 @@ import site.timecapsulearchive.core.domain.member.dto.reqeust.MemberDetailUpdate
 import site.timecapsulearchive.core.domain.member.dto.response.MemberDetailResponse;
 import site.timecapsulearchive.core.domain.member.dto.response.MemberStatusResponse;
 
-@Validated
 public interface MemberApi {
 
     @Operation(

--- a/backend/core/src/main/java/site/timecapsulearchive/core/domain/member/api/MemberApiController.java
+++ b/backend/core/src/main/java/site/timecapsulearchive/core/domain/member/api/MemberApiController.java
@@ -1,0 +1,40 @@
+package site.timecapsulearchive.core.domain.member.api;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import site.timecapsulearchive.core.domain.auth.dto.request.CheckStatusRequest;
+import site.timecapsulearchive.core.domain.member.dto.reqeust.MemberDetailUpdateRequest;
+import site.timecapsulearchive.core.domain.member.dto.response.MemberDetailResponse;
+import site.timecapsulearchive.core.domain.member.dto.response.MemberStatusResponse;
+import site.timecapsulearchive.core.domain.member.service.MemberService;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/")
+public class MemberApiController implements MemberApi {
+
+    private final MemberService memberService;
+
+    @Override
+    public ResponseEntity<MemberDetailResponse> findMemberById() {
+        return null;
+    }
+
+    @Override
+    public ResponseEntity<Void> updateMemberById(MemberDetailUpdateRequest request) {
+        return null;
+    }
+
+    @Override
+    public ResponseEntity<MemberStatusResponse> checkStatus(
+        @RequestBody CheckStatusRequest request
+    ) {
+        return ResponseEntity.ok(memberService.checkStatus(
+            request.authId(),
+            request.socialType())
+        );
+    }
+}

--- a/backend/core/src/main/java/site/timecapsulearchive/core/domain/member/api/MemberApiController.java
+++ b/backend/core/src/main/java/site/timecapsulearchive/core/domain/member/api/MemberApiController.java
@@ -1,5 +1,6 @@
 package site.timecapsulearchive.core.domain.member.api;
 
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -30,7 +31,7 @@ public class MemberApiController implements MemberApi {
 
     @Override
     public ResponseEntity<MemberStatusResponse> checkStatus(
-        @RequestBody CheckStatusRequest request
+        @Valid @RequestBody CheckStatusRequest request
     ) {
         return ResponseEntity.ok(memberService.checkStatus(
             request.authId(),

--- a/backend/core/src/main/java/site/timecapsulearchive/core/domain/member/dto/mapper/MemberMapper.java
+++ b/backend/core/src/main/java/site/timecapsulearchive/core/domain/member/dto/mapper/MemberMapper.java
@@ -2,6 +2,7 @@ package site.timecapsulearchive.core.domain.member.dto.mapper;
 
 import org.springframework.stereotype.Component;
 import site.timecapsulearchive.core.domain.auth.dto.oauth.OAuth2UserInfo;
+import site.timecapsulearchive.core.domain.auth.dto.request.SignUpRequest;
 import site.timecapsulearchive.core.domain.auth.entity.SocialType;
 import site.timecapsulearchive.core.domain.member.entity.Member;
 
@@ -13,6 +14,15 @@ public class MemberMapper {
             .socialType(socialType)
             .email(oAuth2UserInfo.getEmail())
             .profileUrl(oAuth2UserInfo.getImageUrl())
+            .build();
+    }
+
+    public Member signUpRequestToEntity(SignUpRequest request) {
+        return Member.builder()
+            .authId(request.authId())
+            .email(request.email())
+            .profileUrl(request.profileUrl())
+            .socialType(request.socialType())
             .build();
     }
 }

--- a/backend/core/src/main/java/site/timecapsulearchive/core/domain/member/dto/response/MemberStatusResponse.java
+++ b/backend/core/src/main/java/site/timecapsulearchive/core/domain/member/dto/response/MemberStatusResponse.java
@@ -1,0 +1,22 @@
+package site.timecapsulearchive.core.domain.member.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "사용자 상태 확인 응답")
+public record MemberStatusResponse(
+
+    @Schema(description = "사용자 존재 여부")
+    Boolean isExist,
+
+    @Schema(description = "전화번호 인증 여부")
+    Boolean isVerified
+) {
+
+    public static MemberStatusResponse empty() {
+        return new MemberStatusResponse(false, false);
+    }
+
+    public static MemberStatusResponse from(Boolean isVerified) {
+        return new MemberStatusResponse(true, isVerified);
+    }
+}

--- a/backend/core/src/main/java/site/timecapsulearchive/core/domain/member/entity/Member.java
+++ b/backend/core/src/main/java/site/timecapsulearchive/core/domain/member/entity/Member.java
@@ -58,28 +58,39 @@ public class Member extends BaseEntity {
 
     @Column(name = "is_verified", nullable = false)
     private Boolean isVerified;
+
+    @Column(name = "auth_id", nullable = false)
+    private String authId;
+
     @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Capsule> capsules;
+
     @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<GroupInvite> groupInvites;
+
     @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<MemberGroup> groups;
+
     @OneToMany(mappedBy = "friend", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<MemberFriend> friends;
+
     @OneToMany(mappedBy = "owner", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<FriendInvite> friendsRequests;
+
     @OneToMany(mappedBy = "friend", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<FriendInvite> notifications;
+
     @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<History> histories;
 
     @Builder
-    private Member(String profileUrl, SocialType socialType, String email) {
+    private Member(String profileUrl, SocialType socialType, String email, String authId) {
         this.profileUrl = profileUrl;
         this.nickname = "";
         this.socialType = socialType;
         this.email = email;
         this.isVerified = false;
         this.notificationEnabled = false;
+        this.authId = authId;
     }
 }

--- a/backend/core/src/main/java/site/timecapsulearchive/core/domain/member/repository/MemberQueryRepository.java
+++ b/backend/core/src/main/java/site/timecapsulearchive/core/domain/member/repository/MemberQueryRepository.java
@@ -1,0 +1,25 @@
+package site.timecapsulearchive.core.domain.member.repository;
+
+import static site.timecapsulearchive.core.domain.member.entity.QMember.member;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+import site.timecapsulearchive.core.domain.auth.entity.SocialType;
+
+@Repository
+@RequiredArgsConstructor
+public class MemberQueryRepository {
+
+    private final JPAQueryFactory query;
+
+    public Boolean findIsVerifiedByAuthIdAndSocialType(
+        String authId,
+        SocialType socialType
+    ) {
+        return query.select(member.isVerified)
+            .from(member)
+            .where(member.authId.eq(authId).and(member.socialType.eq(socialType)))
+            .fetchOne();
+    }
+}

--- a/backend/core/src/main/java/site/timecapsulearchive/core/domain/member/service/MemberService.java
+++ b/backend/core/src/main/java/site/timecapsulearchive/core/domain/member/service/MemberService.java
@@ -1,0 +1,49 @@
+package site.timecapsulearchive.core.domain.member.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import site.timecapsulearchive.core.domain.auth.entity.SocialType;
+import site.timecapsulearchive.core.domain.member.dto.response.MemberStatusResponse;
+import site.timecapsulearchive.core.domain.member.entity.Member;
+import site.timecapsulearchive.core.domain.member.repository.MemberQueryRepository;
+import site.timecapsulearchive.core.domain.member.repository.MemberRepository;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class MemberService {
+
+    private final MemberRepository memberRepository;
+    private final MemberQueryRepository memberQueryRepository;
+
+    @Transactional
+    public Long createUser(Member member) {
+        Member savedMember = memberRepository.save(member);
+
+        return savedMember.getId();
+    }
+
+    /**
+     * 사용자의 소셜 프로바이더 인증 아이디와 타입을 받아 사용자의 인증 상태를 반환한다.
+     *
+     * @param authId     사용자의 소셜 프로바이더 인증 id
+     * @param socialType 사용자의 소셜 프로바이더 타입
+     * @return 사용자의 인증 상태 {@code isExist, isVerified}
+     */
+    public MemberStatusResponse checkStatus(
+        String authId,
+        SocialType socialType
+    ) {
+        Boolean isVerified = memberQueryRepository.findIsVerifiedByAuthIdAndSocialType(
+            authId,
+            socialType
+        );
+
+        if (isVerified == null) {
+            return MemberStatusResponse.empty();
+        }
+
+        return MemberStatusResponse.from(isVerified);
+    }
+}

--- a/backend/core/src/main/java/site/timecapsulearchive/core/domain/member/service/MemberService.java
+++ b/backend/core/src/main/java/site/timecapsulearchive/core/domain/member/service/MemberService.java
@@ -18,7 +18,7 @@ public class MemberService {
     private final MemberQueryRepository memberQueryRepository;
 
     @Transactional
-    public Long createUser(Member member) {
+    public Long createMember(Member member) {
         Member savedMember = memberRepository.save(member);
 
         return savedMember.getId();

--- a/backend/core/src/main/java/site/timecapsulearchive/core/global/config/QueryDSLConfig.java
+++ b/backend/core/src/main/java/site/timecapsulearchive/core/global/config/QueryDSLConfig.java
@@ -1,0 +1,15 @@
+package site.timecapsulearchive.core.global.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class QueryDSLConfig {
+
+    @Bean
+    public JPAQueryFactory query(EntityManager entityManager) {
+        return new JPAQueryFactory(entityManager);
+    }
+}

--- a/backend/core/src/main/java/site/timecapsulearchive/core/global/config/SwaggerConfig.java
+++ b/backend/core/src/main/java/site/timecapsulearchive/core/global/config/SwaggerConfig.java
@@ -2,6 +2,8 @@ package site.timecapsulearchive.core.global.config;
 
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.servers.Server;
+import java.util.List;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.servlet.config.annotation.EnableWebMvc;
@@ -15,9 +17,22 @@ public class SwaggerConfig {
     @Bean
     public OpenAPI springShopOpenAPI() {
         return new OpenAPI()
-            .info(new Info().title("Archive API")
-                .description("AR을 이용해 추억을 저장하고 공유하는 서비스")
-                .version("v1"));
+            .servers(getServers())
+            .info(getInfo());
+    }
+
+    private List<Server> getServers() {
+        return List.of(
+            new Server()
+                .url("/api")
+                .description("백엔드 api 서버")
+        );
+    }
+
+    private Info getInfo() {
+        return new Info().title("Archive API")
+            .description("AR을 이용해 추억을 저장하고 공유하는 서비스")
+            .version("v1");
     }
 }
 

--- a/backend/core/src/main/resources/db/migration/V1__init.sql
+++ b/backend/core/src/main/resources/db/migration/V1__init.sql
@@ -1,4 +1,4 @@
-CREATE TABLE core.`group`
+CREATE TABLE `group`
 (
     created_at        timestamp NULL,
     group_id          BIGINT AUTO_INCREMENT PRIMARY KEY,
@@ -8,7 +8,7 @@ CREATE TABLE core.`group`
     group_profile_url VARCHAR(255) NOT NULL
 );
 
-CREATE TABLE core.member
+CREATE TABLE member
 (
     is_verified          BIT          NOT NULL,
     notification_enabled BIT          NOT NULL,
@@ -23,7 +23,7 @@ CREATE TABLE core.member
     profile_url          VARCHAR(255) NOT NULL
 );
 
-CREATE TABLE core.capsule_skin
+CREATE TABLE capsule_skin
 (
     capsule_skin_id BIGINT AUTO_INCREMENT PRIMARY KEY,
     created_at      timestamp NULL,
@@ -34,10 +34,10 @@ CREATE TABLE core.capsule_skin
     image_url       VARCHAR(255) NOT NULL,
     motion_name     VARCHAR(255) NOT NULL,
     CONSTRAINT fk_capsule_skin_member_id
-        FOREIGN KEY (member_id) REFERENCES core.member (member_id)
+        FOREIGN KEY (member_id) REFERENCES member (member_id)
 );
 
-CREATE TABLE core.capsule
+CREATE TABLE capsule
 (
     is_opened       BIT          NOT NULL,
     latitude        FLOAT        NOT NULL,
@@ -58,24 +58,24 @@ CREATE TABLE core.capsule
     type            VARCHAR(255) NOT NULL,
     zip_code        VARCHAR(255) NULL,
     CONSTRAINT fk_capsule_group_id
-        FOREIGN KEY (group_id) REFERENCES core.`group` (group_id),
+        FOREIGN KEY (group_id) REFERENCES `group` (group_id),
     CONSTRAINT fk_capsule_member_id
-        FOREIGN KEY (member_id) REFERENCES core.member (member_id),
+        FOREIGN KEY (member_id) REFERENCES member (member_id),
     CONSTRAINT fk_capsule_capsule_skin_id
-        FOREIGN KEY (capsule_skin_id) REFERENCES core.capsule_skin (capsule_skin_id)
+        FOREIGN KEY (capsule_skin_id) REFERENCES capsule_skin (capsule_skin_id)
 );
 
-CREATE TABLE core.friend_invite
+CREATE TABLE friend_invite
 (
     created_at       timestamp NULL,
     friend_invite_id BIGINT AUTO_INCREMENT PRIMARY KEY,
     member_id        BIGINT NOT NULL,
     updated_at       timestamp NULL,
     CONSTRAINT fk_friend_invite_member_id
-        FOREIGN KEY (member_id) REFERENCES core.member (member_id)
+        FOREIGN KEY (member_id) REFERENCES member (member_id)
 );
 
-CREATE TABLE core.group_capsule_open
+CREATE TABLE group_capsule_open
 (
     capsule_id            BIGINT NOT NULL,
     created_at            timestamp NULL,
@@ -83,22 +83,22 @@ CREATE TABLE core.group_capsule_open
     member_id             BIGINT NOT NULL,
     updated_at            timestamp NULL,
     CONSTRAINT fk_group_capsule_open_member_id
-        FOREIGN KEY (member_id) REFERENCES core.member (member_id),
+        FOREIGN KEY (member_id) REFERENCES member (member_id),
     CONSTRAINT fk_group_capsule_open_capsule_id
-        FOREIGN KEY (capsule_id) REFERENCES core.capsule (capsule_id)
+        FOREIGN KEY (capsule_id) REFERENCES capsule (capsule_id)
 );
 
-CREATE TABLE core.group_invite
+CREATE TABLE group_invite
 (
     created_at      timestamp NULL,
     group_invite_id BIGINT AUTO_INCREMENT PRIMARY KEY,
     member_id       BIGINT NOT NULL,
     updated_at      timestamp NULL,
     CONSTRAINT fk_group_invite_member_id
-        FOREIGN KEY (member_id) REFERENCES core.member (member_id)
+        FOREIGN KEY (member_id) REFERENCES member (member_id)
 );
 
-CREATE TABLE core.history
+CREATE TABLE history
 (
     created_at timestamp NULL,
     history_id BIGINT AUTO_INCREMENT PRIMARY KEY,
@@ -106,10 +106,10 @@ CREATE TABLE core.history
     updated_at timestamp NULL,
     title      VARCHAR(255) NOT NULL,
     CONSTRAINT fk_history_member_id
-        FOREIGN KEY (member_id) REFERENCES core.member (member_id)
+        FOREIGN KEY (member_id) REFERENCES member (member_id)
 );
 
-CREATE TABLE core.image
+CREATE TABLE image
 (
     capsule_id BIGINT       NOT NULL,
     created_at timestamp NULL,
@@ -119,10 +119,10 @@ CREATE TABLE core.image
     image_name VARCHAR(255) NOT NULL,
     image_url  VARCHAR(255) NOT NULL,
     CONSTRAINT fk_image_capsule_id
-        FOREIGN KEY (capsule_id) REFERENCES core.capsule (capsule_id)
+        FOREIGN KEY (capsule_id) REFERENCES capsule (capsule_id)
 );
 
-CREATE TABLE core.history_image
+CREATE TABLE history_image
 (
     created_at       timestamp NULL,
     history_id       BIGINT NOT NULL,
@@ -130,22 +130,22 @@ CREATE TABLE core.history_image
     image_id         BIGINT NOT NULL,
     updated_at       timestamp NULL,
     CONSTRAINT fk_history_image_image_id
-        FOREIGN KEY (image_id) REFERENCES core.image (image_id),
+        FOREIGN KEY (image_id) REFERENCES image (image_id),
     CONSTRAINT fk_history_image_history_id
-        FOREIGN KEY (history_id) REFERENCES core.history (history_id)
+        FOREIGN KEY (history_id) REFERENCES history (history_id)
 );
 
-CREATE TABLE core.member_friend
+CREATE TABLE member_friend
 (
     created_at       timestamp NULL,
     member_friend_id BIGINT AUTO_INCREMENT PRIMARY KEY,
     member_id        BIGINT NOT NULL,
     updated_at       timestamp NULL,
     CONSTRAINT fk_member_friend_member_id
-        FOREIGN KEY (member_id) REFERENCES core.member (member_id)
+        FOREIGN KEY (member_id) REFERENCES member (member_id)
 );
 
-CREATE TABLE core.member_group
+CREATE TABLE member_group
 (
     is_owner        BIT    NOT NULL,
     created_at      timestamp NULL,
@@ -154,12 +154,12 @@ CREATE TABLE core.member_group
     member_id       BIGINT NOT NULL,
     updated_at      timestamp NULL,
     CONSTRAINT fk_member_group_group_id
-        FOREIGN KEY (group_id) REFERENCES core.`group` (group_id),
+        FOREIGN KEY (group_id) REFERENCES `group` (group_id),
     CONSTRAINT fk_member_group_member_id
-        FOREIGN KEY (member_id) REFERENCES core.member (member_id)
+        FOREIGN KEY (member_id) REFERENCES member (member_id)
 );
 
-CREATE TABLE core.video
+CREATE TABLE video
 (
     size       INT          NOT NULL,
     capsule_id BIGINT       NOT NULL,
@@ -167,5 +167,5 @@ CREATE TABLE core.video
     video_name VARCHAR(255) NOT NULL,
     video_url  VARCHAR(255) NOT NULL,
     CONSTRAINT fk_video_capsule_id
-        FOREIGN KEY (capsule_id) REFERENCES core.capsule (capsule_id)
+        FOREIGN KEY (capsule_id) REFERENCES capsule (capsule_id)
 );

--- a/backend/core/src/main/resources/db/migration/V2__member_update.sql
+++ b/backend/core/src/main/resources/db/migration/V2__member_update.sql
@@ -1,3 +1,3 @@
 -- Add new columns
 ALTER TABLE member
-    CHANGE COLUMN oauth2_provider social_type VARCHAR(255) NOT NULL;
+    CHANGE COLUMN oauth2_provider social_type VARCHAR (255) NOT NULL;

--- a/backend/core/src/main/resources/db/migration/V3__member_update.sql
+++ b/backend/core/src/main/resources/db/migration/V3__member_update.sql
@@ -1,0 +1,3 @@
+-- Add new columns auth_id
+ALTER TABLE member
+    ADD COLUMN auth_id VARCHAR(255) NOT NULL;


### PR DESCRIPTION
## 작업 내용 (Content)
- 카카오톡, 구글 앱으로 로그인 할 수 있는 엔드포인트 추가
- 소셜 프로바이더의 인증 id로 멤버 상태 체크 엔드포인트 추가
- Dto Validation 추가
- 메서드 분리하기 위해 mapper 사용

## 링크 (Links)
- [JIRA 티켓 이름](https://archivetimecapsule.atlassian.net/jira/software/projects/ARCH/boards/1?selectedIssue=ARCH-114)
- #37 

## 기타 사항 (Etc)
- OAuth2 엔드포인트는 그대로 유지하고 앱을 통한 로그인 추가

## Merge 전 필요 작업 (Checklist before merge)

## 희망 리뷰 완료 일 (Expected due date)
