### PR TITLE
feat: 내 페이지 비밀 캡슐 조회(무한 스크롤) #102

### DIFF
--- a/backend/core/src/main/java/site/timecapsulearchive/core/domain/capsule/api/CapsuleApi.java
+++ b/backend/core/src/main/java/site/timecapsulearchive/core/domain/capsule/api/CapsuleApi.java
@@ -35,11 +35,16 @@ public interface CapsuleApi {
     @GetMapping(
         produces = {"application/json"}
     )
-    ResponseEntity<MyCapsulePageResponse> findCapsulesByMemberId(
-        @Parameter(in = ParameterIn.QUERY, description = "페이지 크기", required = true, schema = @Schema())
-        @NotNull @Valid @RequestParam(value = "size") Long size,
+    ResponseEntity<ApiSpec<MyCapsulePageResponse>> findCapsulesByMemberId(
+        Long memberId,
 
-        @Parameter(in = ParameterIn.QUERY, description = "마지막 캡슐 아이디", required = true, schema = @Schema())
+        @Parameter(in = ParameterIn.QUERY, description = "페이지 위치", required = true)
+        @NotNull @Valid @RequestParam(value = "page") int page,
+
+        @Parameter(in = ParameterIn.QUERY, description = "페이지 크기", required = true)
+        @NotNull @Valid @RequestParam(value = "size") int size,
+
+        @Parameter(in = ParameterIn.QUERY, description = "마지막 캡슐 아이디", required = true)
         @NotNull @Valid @RequestParam(value = "capsule_id") Long capsuleId
     );
 

--- a/backend/core/src/main/java/site/timecapsulearchive/core/domain/capsule/api/CapsuleApi.java
+++ b/backend/core/src/main/java/site/timecapsulearchive/core/domain/capsule/api/CapsuleApi.java
@@ -13,41 +13,11 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import site.timecapsulearchive.core.domain.capsule.dto.response.ImagesPageResponse;
-import site.timecapsulearchive.core.domain.capsule.dto.response.MyCapsulePageResponse;
 import site.timecapsulearchive.core.domain.capsule.dto.response.NearbyCapsuleResponse;
 import site.timecapsulearchive.core.domain.capsule.entity.CapsuleType;
 import site.timecapsulearchive.core.global.common.response.ApiSpec;
 
 public interface CapsuleApi {
-
-    @Operation(
-        summary = "내 캡슐 목록 조회",
-        description = "사용자가 생성한 캡슐 목록을 조회한다.",
-        security = {@SecurityRequirement(name = "user_token")},
-        tags = {"capsule"}
-    )
-    @ApiResponses(value = {
-        @ApiResponse(
-            responseCode = "200",
-            description = "처리 완료"
-        )
-    })
-    @GetMapping(
-        produces = {"application/json"}
-    )
-    ResponseEntity<ApiSpec<MyCapsulePageResponse>> findCapsulesByMemberId(
-        Long memberId,
-
-        @Parameter(in = ParameterIn.QUERY, description = "페이지 위치", required = true)
-        @NotNull @Valid @RequestParam(value = "page") int page,
-
-        @Parameter(in = ParameterIn.QUERY, description = "페이지 크기", required = true)
-        @NotNull @Valid @RequestParam(value = "size") int size,
-
-        @Parameter(in = ParameterIn.QUERY, description = "마지막 캡슐 아이디", required = true)
-        @NotNull @Valid @RequestParam(value = "capsule_id") Long capsuleId
-    );
-
 
     @Operation(
         summary = "캡슐에 담겨있는 이미지 목록 조회",

--- a/backend/core/src/main/java/site/timecapsulearchive/core/domain/capsule/api/CapsuleApiController.java
+++ b/backend/core/src/main/java/site/timecapsulearchive/core/domain/capsule/api/CapsuleApiController.java
@@ -1,9 +1,6 @@
 package site.timecapsulearchive.core.domain.capsule.api;
 
-import jakarta.validation.Valid;
-import jakarta.validation.constraints.NotNull;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.PageRequest;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -11,7 +8,6 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import site.timecapsulearchive.core.domain.capsule.dto.CoordinateRangeRequestDto;
 import site.timecapsulearchive.core.domain.capsule.dto.response.ImagesPageResponse;
-import site.timecapsulearchive.core.domain.capsule.dto.response.MyCapsulePageResponse;
 import site.timecapsulearchive.core.domain.capsule.dto.response.NearbyCapsuleResponse;
 import site.timecapsulearchive.core.domain.capsule.entity.CapsuleType;
 import site.timecapsulearchive.core.domain.capsule.service.CapsuleService;
@@ -26,25 +22,6 @@ public class CapsuleApiController implements CapsuleApi {
     private final CapsuleService capsuleService;
 
     @Override
-    public ResponseEntity<ApiSpec<MyCapsulePageResponse>> findCapsulesByMemberId(
-        @AuthenticationPrincipal Long memberId,
-        @NotNull @Valid @RequestParam(defaultValue = "0", value = "page") int page,
-        @NotNull @Valid @RequestParam(defaultValue = "20", value = "size") int size,
-        @NotNull @Valid @RequestParam(defaultValue = "0", value = "capsuleId") Long capsuleId
-    ) {
-        return ResponseEntity.ok(
-            ApiSpec.success(
-                SuccessCode.SUCCESS,
-                capsuleService.findCapsuleListByMemberId(
-                    memberId,
-                    PageRequest.of(page, size),
-                    capsuleId
-                )
-            )
-        );
-    }
-
-    @Override
     public ResponseEntity<ImagesPageResponse> findImages(Long size, Long capsuleId) {
         return null;
     }
@@ -52,10 +29,10 @@ public class CapsuleApiController implements CapsuleApi {
     @Override
     public ResponseEntity<ApiSpec<NearbyCapsuleResponse>> getNearByCapsules(
         @AuthenticationPrincipal Long memberId,
-        @NotNull @Valid @RequestParam(value = "latitude") double latitude,
-        @NotNull @Valid @RequestParam(value = "longitude") double longitude,
-        @NotNull @Valid @RequestParam(value = "distance") double distance,
-        @NotNull @Valid @RequestParam(value = "capsule_type", required = false, defaultValue = "ALL"
+        @RequestParam(value = "latitude") double latitude,
+        @RequestParam(value = "longitude") double longitude,
+        @RequestParam(value = "distance") double distance,
+        @RequestParam(value = "capsule_type", required = false, defaultValue = "ALL"
         ) CapsuleType capsuleType
     ) {
         return ResponseEntity.ok(

--- a/backend/core/src/main/java/site/timecapsulearchive/core/domain/capsule/api/CapsuleApiController.java
+++ b/backend/core/src/main/java/site/timecapsulearchive/core/domain/capsule/api/CapsuleApiController.java
@@ -3,6 +3,7 @@ package site.timecapsulearchive.core.domain.capsule.api;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -25,8 +26,22 @@ public class CapsuleApiController implements CapsuleApi {
     private final CapsuleService capsuleService;
 
     @Override
-    public ResponseEntity<MyCapsulePageResponse> findCapsulesByMemberId(Long size, Long capsuleId) {
-        return null;
+    public ResponseEntity<ApiSpec<MyCapsulePageResponse>> findCapsulesByMemberId(
+        @AuthenticationPrincipal Long memberId,
+        @NotNull @Valid @RequestParam(defaultValue = "0", value = "page") int page,
+        @NotNull @Valid @RequestParam(defaultValue = "20", value = "size") int size,
+        @NotNull @Valid @RequestParam(defaultValue = "0", value = "capsuleId") Long capsuleId
+    ) {
+        return ResponseEntity.ok(
+            ApiSpec.success(
+                SuccessCode.SUCCESS,
+                capsuleService.findCapsuleListByMemberId(
+                    memberId,
+                    PageRequest.of(page, size),
+                    capsuleId
+                )
+            )
+        );
     }
 
     @Override

--- a/backend/core/src/main/java/site/timecapsulearchive/core/domain/capsule/api/secret_c/SecretCapsuleApi.java
+++ b/backend/core/src/main/java/site/timecapsulearchive/core/domain/capsule/api/secret_c/SecretCapsuleApi.java
@@ -7,12 +7,17 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
+import java.time.ZonedDateTime;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import site.timecapsulearchive.core.domain.capsule.dto.response.MyCapsulePageResponse;
 import site.timecapsulearchive.core.domain.capsule.dto.secret_c.reqeust.SecretCapsuleCreateRequest;
 import site.timecapsulearchive.core.domain.capsule.dto.secret_c.reqeust.SecretCapsuleUpdateRequest;
 import site.timecapsulearchive.core.domain.capsule.dto.secret_c.response.SecretCapsuleDetailResponse;
@@ -40,6 +45,32 @@ public interface SecretCapsuleApi {
     ResponseEntity<ApiSpec<String>> createSecretCapsule(
         Long memberId,
         SecretCapsuleCreateRequest request
+    );
+
+    @Operation(
+        summary = "내 비밀 캡슐 목록 조회",
+        description = "사용자가 생성한 비밀 캡슐 목록을 조회한다.",
+        security = {@SecurityRequirement(name = "user_token")},
+        tags = {"capsule"}
+    )
+    @ApiResponses(value = {
+        @ApiResponse(
+            responseCode = "200",
+            description = "처리 완료"
+        )
+    })
+    @GetMapping(
+        value = "/capsules",
+        produces = {"application/json"}
+    )
+    ResponseEntity<ApiSpec<MyCapsulePageResponse>> getMySecreteCapsules(
+        Long memberId,
+
+        @Parameter(in = ParameterIn.QUERY, description = "페이지 크기", required = true)
+        @NotNull @Valid @RequestParam(value = "size") int size,
+
+        @Parameter(in = ParameterIn.QUERY, description = "마지막 캡슐 생성 시간", required = true)
+        @NotNull @Valid @RequestParam(value = "createdAt") ZonedDateTime createdAt
     );
 
     @Operation(

--- a/backend/core/src/main/java/site/timecapsulearchive/core/domain/capsule/api/secret_c/SecretCapsuleApi.java
+++ b/backend/core/src/main/java/site/timecapsulearchive/core/domain/capsule/api/secret_c/SecretCapsuleApi.java
@@ -81,7 +81,7 @@ public interface SecretCapsuleApi {
         value = "/capsules/{capsule_id}/summary",
         produces = {"application/json"}
     )
-    ResponseEntity<ApiSpec<SecretCapsuleSummaryResponse>> getSecretCapsuleSummary(
+    ResponseEntity<ApiSpec<SecretCapsuleSummaryResponse>> findSecretCapsuleSummary(
         Long memberId,
 
         @Parameter(in = ParameterIn.PATH, description = "비밀 캡슐 아이디", required = true)

--- a/backend/core/src/main/java/site/timecapsulearchive/core/domain/capsule/api/secret_c/SecretCapsuleApiController.java
+++ b/backend/core/src/main/java/site/timecapsulearchive/core/domain/capsule/api/secret_c/SecretCapsuleApiController.java
@@ -54,8 +54,7 @@ public class SecretCapsuleApiController implements SecretCapsuleApi {
         );
     }
 
-    @Override
-    public ResponseEntity<ApiSpec<SecretCapsuleSummaryResponse>> getSecretCapsuleSummary(
+    public ResponseEntity<ApiSpec<SecretCapsuleSummaryResponse>> findSecretCapsuleSummary(
         @AuthenticationPrincipal Long memberId,
         @NotNull @PathVariable("capsule_id") Long capsuleId
     ) {

--- a/backend/core/src/main/java/site/timecapsulearchive/core/domain/capsule/api/secret_c/SecretCapsuleApiController.java
+++ b/backend/core/src/main/java/site/timecapsulearchive/core/domain/capsule/api/secret_c/SecretCapsuleApiController.java
@@ -1,14 +1,17 @@
 package site.timecapsulearchive.core.domain.capsule.api.secret_c;
 
 import jakarta.validation.constraints.NotNull;
+import java.time.ZonedDateTime;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import site.timecapsulearchive.core.domain.capsule.dto.mapper.CapsuleMapper;
+import site.timecapsulearchive.core.domain.capsule.dto.response.MyCapsulePageResponse;
 import site.timecapsulearchive.core.domain.capsule.dto.secret_c.reqeust.SecretCapsuleCreateRequest;
 import site.timecapsulearchive.core.domain.capsule.dto.secret_c.reqeust.SecretCapsuleUpdateRequest;
 import site.timecapsulearchive.core.domain.capsule.dto.secret_c.response.SecretCapsuleDetailResponse;
@@ -38,6 +41,24 @@ public class SecretCapsuleApiController implements SecretCapsuleApi {
         return ResponseEntity.ok(
             ApiSpec.empty(
                 SuccessCode.SUCCESS
+            )
+        );
+    }
+
+    @Override
+    public ResponseEntity<ApiSpec<MyCapsulePageResponse>> getMySecreteCapsules(
+        @AuthenticationPrincipal Long memberId,
+        @RequestParam(defaultValue = "20", value = "size") int size,
+        @RequestParam(defaultValue = "0", value = "createdAt") ZonedDateTime createdAt
+    ) {
+        return ResponseEntity.ok(
+            ApiSpec.success(
+                SuccessCode.SUCCESS,
+                secreteCapsuleService.findSecreteCapsuleListByMemberId(
+                    memberId,
+                    size,
+                    createdAt
+                )
             )
         );
     }

--- a/backend/core/src/main/java/site/timecapsulearchive/core/domain/capsule/dto/mapper/CapsuleMapper.java
+++ b/backend/core/src/main/java/site/timecapsulearchive/core/domain/capsule/dto/mapper/CapsuleMapper.java
@@ -118,7 +118,7 @@ public class CapsuleMapper {
             .nickname(dto.nickname())
             .address(dto.address())
             .isOpened(dto.isOpened())
-            .createdDate(dto.createdAt().withZoneSameInstant(ZONE_ID))
+            .createdDate(dto.createdAt().withZoneSameInstant(ASIA_SEOUL))
             .title(dto.title())
             .build();
     }

--- a/backend/core/src/main/java/site/timecapsulearchive/core/domain/capsule/dto/mapper/CapsuleMapper.java
+++ b/backend/core/src/main/java/site/timecapsulearchive/core/domain/capsule/dto/mapper/CapsuleMapper.java
@@ -1,6 +1,8 @@
 package site.timecapsulearchive.core.domain.capsule.dto.mapper;
 
 import java.time.ZoneId;
+import java.util.List;
+import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import org.locationtech.jts.geom.Point;
 import org.springframework.data.domain.Slice;
@@ -10,6 +12,7 @@ import site.timecapsulearchive.core.domain.capsule.dto.response.CapsuleSummaryRe
 import site.timecapsulearchive.core.domain.capsule.dto.response.MyCapsulePageResponse;
 import site.timecapsulearchive.core.domain.capsule.dto.secret_c.SecretCapsuleCreateRequestDto;
 import site.timecapsulearchive.core.domain.capsule.dto.secret_c.SecretCapsuleSummaryDto;
+import site.timecapsulearchive.core.domain.capsule.dto.secret_c.SecreteCapsuleDetail;
 import site.timecapsulearchive.core.domain.capsule.dto.secret_c.SecreteCapsuleDetailDto;
 import site.timecapsulearchive.core.domain.capsule.dto.secret_c.reqeust.SecretCapsuleCreateRequest;
 import site.timecapsulearchive.core.domain.capsule.dto.secret_c.response.SecretCapsuleDetailResponse;
@@ -24,7 +27,7 @@ import site.timecapsulearchive.core.global.geography.GeoTransformer;
 @RequiredArgsConstructor
 public class CapsuleMapper {
 
-    private static final ZoneId ZONE_ID = ZoneId.of("Asia/Seoul");
+    private static final ZoneId ASIA_SEOUL = ZoneId.of("Asia/Seoul");
 
     private final GeoTransformer geoTransformer;
 
@@ -72,7 +75,7 @@ public class CapsuleMapper {
             .nickname(dto.nickname())
             .capsuleSkinUrl(dto.skinUrl())
             .title(dto.title())
-            .dueDate(dto.dueDate().withZoneSameInstant(ZONE_ID))
+            .dueDate(dto.dueDate().withZoneSameInstant(ASIA_SEOUL))
             .capsuleType(dto.capsuleType())
             .build();
     }
@@ -84,10 +87,10 @@ public class CapsuleMapper {
             .nickname(dto.nickname())
             .skinUrl(dto.skinUrl())
             .title(dto.title())
-            .dueDate(dto.dueDate().withZoneSameInstant(ZONE_ID))
+            .dueDate(dto.dueDate().withZoneSameInstant(ASIA_SEOUL))
             .address(dto.address())
             .isOpened(dto.isOpened())
-            .createdAt(dto.createdAt().withZoneSameInstant(ZONE_ID))
+            .createdAt(dto.createdAt().withZoneSameInstant(ASIA_SEOUL))
             .build();
     }
 
@@ -95,9 +98,9 @@ public class CapsuleMapper {
         SecreteCapsuleDetailDto dto) {
         return SecretCapsuleDetailResponse.builder()
             .capsuleSkinUrl(dto.capsuleSkinUrl())
-            .dueDate(dto.dueDate().withZoneSameInstant(ZONE_ID))
+            .dueDate(dto.dueDate().withZoneSameInstant(ASIA_SEOUL))
             .nickname(dto.nickname())
-            .createdDate(dto.createdAt().withZoneSameInstant(ZONE_ID))
+            .createdDate(dto.createdAt().withZoneSameInstant(ASIA_SEOUL))
             .address(dto.address())
             .title(dto.title())
             .content(dto.content())
@@ -111,7 +114,7 @@ public class CapsuleMapper {
         SecreteCapsuleDetailDto dto) {
         return SecretCapsuleDetailResponse.builder()
             .capsuleSkinUrl(dto.capsuleSkinUrl())
-            .dueDate(dto.dueDate().withZoneSameInstant(ZONE_ID))
+            .dueDate(dto.dueDate().withZoneSameInstant(ASIA_SEOUL))
             .nickname(dto.nickname())
             .address(dto.address())
             .isOpened(dto.isOpened())
@@ -127,5 +130,26 @@ public class CapsuleMapper {
             capsuleDetailSlice.hasNext(),
             capsuleDetailSlice.hasPrevious()
         );
+    }
+
+    public SecreteCapsuleDetailDto secreteCapsuleDetailToDto(
+        SecreteCapsuleDetail detail,
+        Map<Long, List<String>> imageUrls,
+        Map<Long, List<String>> videoUrls
+    ) {
+        return SecreteCapsuleDetailDto.builder()
+            .capsuleId(detail.capsuleId())
+            .capsuleSkinUrl(detail.capsuleSkinUrl())
+            .dueDate(detail.dueDate().withZoneSameInstant(ASIA_SEOUL))
+            .nickname(detail.nickname())
+            .createdAt(detail.createdAt().withZoneSameInstant(ASIA_SEOUL))
+            .address(detail.address())
+            .title(detail.title())
+            .content(detail.content())
+            .images(imageUrls.get(detail.capsuleId()))
+            .videos(videoUrls.get(detail.capsuleId()))
+            .isOpened(detail.isOpened())
+            .build();
+
     }
 }

--- a/backend/core/src/main/java/site/timecapsulearchive/core/domain/capsule/dto/mapper/CapsuleMapper.java
+++ b/backend/core/src/main/java/site/timecapsulearchive/core/domain/capsule/dto/mapper/CapsuleMapper.java
@@ -3,9 +3,11 @@ package site.timecapsulearchive.core.domain.capsule.dto.mapper;
 import java.time.ZoneId;
 import lombok.RequiredArgsConstructor;
 import org.locationtech.jts.geom.Point;
+import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Component;
 import site.timecapsulearchive.core.domain.capsule.dto.CapsuleSummaryDto;
 import site.timecapsulearchive.core.domain.capsule.dto.response.CapsuleSummaryResponse;
+import site.timecapsulearchive.core.domain.capsule.dto.response.MyCapsulePageResponse;
 import site.timecapsulearchive.core.domain.capsule.dto.secret_c.SecretCapsuleCreateRequestDto;
 import site.timecapsulearchive.core.domain.capsule.dto.secret_c.SecretCapsuleSummaryDto;
 import site.timecapsulearchive.core.domain.capsule.dto.secret_c.SecreteCapsuleDetailDto;
@@ -116,5 +118,14 @@ public class CapsuleMapper {
             .createdDate(dto.createdAt())
             .title(dto.title())
             .build();
+    }
+
+    public MyCapsulePageResponse capsuleDetailSliceToResponse(
+        Slice<SecreteCapsuleDetailDto> capsuleDetailSlice) {
+        return new MyCapsulePageResponse(
+            capsuleDetailSlice.getContent(),
+            capsuleDetailSlice.hasNext(),
+            capsuleDetailSlice.hasPrevious()
+        );
     }
 }

--- a/backend/core/src/main/java/site/timecapsulearchive/core/domain/capsule/dto/response/MyCapsulePageResponse.java
+++ b/backend/core/src/main/java/site/timecapsulearchive/core/domain/capsule/dto/response/MyCapsulePageResponse.java
@@ -2,12 +2,13 @@ package site.timecapsulearchive.core.domain.capsule.dto.response;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.util.List;
+import site.timecapsulearchive.core.domain.capsule.dto.secret_c.SecreteCapsuleDetailDto;
 
 @Schema(description = "내가 생성한 캡슐 페이징")
 public record MyCapsulePageResponse(
 
-    @Schema(description = "캡슐 요약 정보 리스트")
-    List<CapsuleSummaryResponse> capsules,
+    @Schema(description = "캡슐 상세 정보 리스트")
+    List<SecreteCapsuleDetailDto> capsules,
 
     @Schema(description = "다음 페이지 유무")
     Boolean hasNext,

--- a/backend/core/src/main/java/site/timecapsulearchive/core/domain/capsule/dto/secret_c/SecreteCapsuleDetail.java
+++ b/backend/core/src/main/java/site/timecapsulearchive/core/domain/capsule/dto/secret_c/SecreteCapsuleDetail.java
@@ -1,12 +1,8 @@
 package site.timecapsulearchive.core.domain.capsule.dto.secret_c;
 
 import java.time.ZonedDateTime;
-import java.util.List;
-import lombok.Builder;
 
-@Builder
-public record SecreteCapsuleDetailDto(
-
+public record SecreteCapsuleDetail(
     Long capsuleId,
     String capsuleSkinUrl,
     ZonedDateTime dueDate,
@@ -15,8 +11,6 @@ public record SecreteCapsuleDetailDto(
     String address,
     String title,
     String content,
-    List<String> images,
-    List<String> videos,
     Boolean isOpened
 ) {
 

--- a/backend/core/src/main/java/site/timecapsulearchive/core/domain/capsule/dto/secret_c/SecreteCapsuleDetailDto.java
+++ b/backend/core/src/main/java/site/timecapsulearchive/core/domain/capsule/dto/secret_c/SecreteCapsuleDetailDto.java
@@ -5,6 +5,7 @@ import java.util.List;
 
 public record SecreteCapsuleDetailDto(
 
+    Long capsuleId,
     String capsuleSkinUrl,
     ZonedDateTime dueDate,
     String nickname,

--- a/backend/core/src/main/java/site/timecapsulearchive/core/domain/capsule/service/CapsuleService.java
+++ b/backend/core/src/main/java/site/timecapsulearchive/core/domain/capsule/service/CapsuleService.java
@@ -3,10 +3,14 @@ package site.timecapsulearchive.core.domain.capsule.service;
 import lombok.RequiredArgsConstructor;
 import org.locationtech.jts.geom.Point;
 import org.locationtech.jts.geom.Polygon;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import site.timecapsulearchive.core.domain.capsule.dto.CoordinateRangeRequestDto;
 import site.timecapsulearchive.core.domain.capsule.dto.mapper.CapsuleMapper;
+import site.timecapsulearchive.core.domain.capsule.dto.response.MyCapsulePageResponse;
 import site.timecapsulearchive.core.domain.capsule.dto.response.NearbyCapsuleResponse;
+import site.timecapsulearchive.core.domain.capsule.dto.secret_c.SecreteCapsuleDetailDto;
 import site.timecapsulearchive.core.domain.capsule.entity.CapsuleType;
 import site.timecapsulearchive.core.domain.capsule.repository.CapsuleQueryRepository;
 import site.timecapsulearchive.core.global.geography.GeoTransformer;
@@ -44,5 +48,16 @@ public class CapsuleService {
                 .map(capsuleMapper::capsuleSummaryDtoToResponse)
                 .toList()
         );
+    }
+
+    public MyCapsulePageResponse findCapsuleListByMemberId(
+        Long memberId,
+        Pageable pageable,
+        Long capsuleId
+    ) {
+        Slice<SecreteCapsuleDetailDto> capsuleDetailSlice = capsuleQueryRepository
+            .findCapsuleSliceByMemberId(memberId, pageable, capsuleId);
+
+        return capsuleMapper.capsuleDetailSliceToResponse(capsuleDetailSlice);
     }
 }

--- a/backend/core/src/main/java/site/timecapsulearchive/core/domain/capsule/service/CapsuleService.java
+++ b/backend/core/src/main/java/site/timecapsulearchive/core/domain/capsule/service/CapsuleService.java
@@ -3,14 +3,10 @@ package site.timecapsulearchive.core.domain.capsule.service;
 import lombok.RequiredArgsConstructor;
 import org.locationtech.jts.geom.Point;
 import org.locationtech.jts.geom.Polygon;
-import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import site.timecapsulearchive.core.domain.capsule.dto.CoordinateRangeRequestDto;
 import site.timecapsulearchive.core.domain.capsule.dto.mapper.CapsuleMapper;
-import site.timecapsulearchive.core.domain.capsule.dto.response.MyCapsulePageResponse;
 import site.timecapsulearchive.core.domain.capsule.dto.response.NearbyCapsuleResponse;
-import site.timecapsulearchive.core.domain.capsule.dto.secret_c.SecreteCapsuleDetailDto;
 import site.timecapsulearchive.core.domain.capsule.entity.CapsuleType;
 import site.timecapsulearchive.core.domain.capsule.repository.CapsuleQueryRepository;
 import site.timecapsulearchive.core.global.geography.GeoTransformer;
@@ -48,16 +44,5 @@ public class CapsuleService {
                 .map(capsuleMapper::capsuleSummaryDtoToResponse)
                 .toList()
         );
-    }
-
-    public MyCapsulePageResponse findCapsuleListByMemberId(
-        Long memberId,
-        Pageable pageable,
-        Long capsuleId
-    ) {
-        Slice<SecreteCapsuleDetailDto> capsuleDetailSlice = capsuleQueryRepository
-            .findCapsuleSliceByMemberId(memberId, pageable, capsuleId);
-
-        return capsuleMapper.capsuleDetailSliceToResponse(capsuleDetailSlice);
     }
 }

--- a/backend/core/src/main/java/site/timecapsulearchive/core/domain/capsule/service/SecreteCapsuleService.java
+++ b/backend/core/src/main/java/site/timecapsulearchive/core/domain/capsule/service/SecreteCapsuleService.java
@@ -70,11 +70,11 @@ public class SecreteCapsuleService {
 
 
     /**
-     *
-     * @param memberId
-     * @param size
-     * @param createdAt
-     * @return
+     * 멤버 아이디와 마지막 캡슐 생성 날짜를 받아서 내 페이지 비밀 캡슐을 조회한다.
+     * @param memberId  캡슐을 생성할 멤버 아이디
+     * @param size      페이지 사이즈
+     * @param createdAt 마지막 캡슐 생성 날짜
+     * @return 내 페이지에서 비밀 캡슐을 조회한다.
      */
     public MyCapsulePageResponse findSecreteCapsuleListByMemberId(
         Long memberId,

--- a/backend/core/src/main/java/site/timecapsulearchive/core/domain/capsule/service/SecreteCapsuleService.java
+++ b/backend/core/src/main/java/site/timecapsulearchive/core/domain/capsule/service/SecreteCapsuleService.java
@@ -3,8 +3,10 @@ package site.timecapsulearchive.core.domain.capsule.service;
 import java.time.ZonedDateTime;
 import lombok.RequiredArgsConstructor;
 import org.locationtech.jts.geom.Point;
+import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import site.timecapsulearchive.core.domain.capsule.dto.mapper.CapsuleMapper;
+import site.timecapsulearchive.core.domain.capsule.dto.response.MyCapsulePageResponse;
 import site.timecapsulearchive.core.domain.capsule.dto.secret_c.SecretCapsuleCreateRequestDto;
 import site.timecapsulearchive.core.domain.capsule.dto.secret_c.SecretCapsuleSummaryDto;
 import site.timecapsulearchive.core.domain.capsule.dto.secret_c.SecreteCapsuleDetailDto;
@@ -64,6 +66,25 @@ public class SecreteCapsuleService {
 
         mediaService.saveMediaData(newCapsule, dto.directory(), findMember.getId(),
             dto.fileNames());
+    }
+
+
+    /**
+     *
+     * @param memberId
+     * @param size
+     * @param createdAt
+     * @return
+     */
+    public MyCapsulePageResponse findSecreteCapsuleListByMemberId(
+        Long memberId,
+        int size,
+        ZonedDateTime createdAt
+    ) {
+        Slice<SecreteCapsuleDetailDto> capsuleDetailSlice = capsuleQueryRepository
+            .findSecreteCapsuleSliceByMemberId(memberId, size, createdAt);
+
+        return capsuleMapper.capsuleDetailSliceToResponse(capsuleDetailSlice);
     }
 
     /**

--- a/backend/core/src/main/java/site/timecapsulearchive/core/domain/member/service/MemberService.java
+++ b/backend/core/src/main/java/site/timecapsulearchive/core/domain/member/service/MemberService.java
@@ -1,6 +1,5 @@
 package site.timecapsulearchive.core.domain.member.service;
 
-import java.nio.charset.StandardCharsets;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;

--- a/backend/core/src/main/java/site/timecapsulearchive/core/global/common/converter/ZonedDateTimeConverter.java
+++ b/backend/core/src/main/java/site/timecapsulearchive/core/global/common/converter/ZonedDateTimeConverter.java
@@ -1,0 +1,18 @@
+package site.timecapsulearchive.core.global.common.converter;
+
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.convert.converter.Converter;
+
+@Configuration
+public class ZonedDateTimeConverter implements Converter<String, ZonedDateTime> {
+
+    @Override
+    public ZonedDateTime convert(String source) {
+        ZonedDateTime zonedDateTime = ZonedDateTime.parse(source, DateTimeFormatter.ISO_DATE_TIME);
+
+        return zonedDateTime.withZoneSameInstant(ZoneOffset.UTC);
+    }
+}

--- a/backend/core/src/main/java/site/timecapsulearchive/core/global/config/WebMvcConfig.java
+++ b/backend/core/src/main/java/site/timecapsulearchive/core/global/config/WebMvcConfig.java
@@ -2,9 +2,11 @@ package site.timecapsulearchive.core.global.config;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.format.FormatterRegistry;
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 import site.timecapsulearchive.core.global.api.limit.ApiLimitCheckInterceptor;
+import site.timecapsulearchive.core.global.common.converter.ZonedDateTimeConverter;
 
 @Configuration
 @RequiredArgsConstructor
@@ -16,5 +18,10 @@ public class WebMvcConfig implements WebMvcConfigurer {
     public void addInterceptors(InterceptorRegistry registry) {
         registry.addInterceptor(apiLimitCheckInterceptor)
             .addPathPatterns("/auth/verification/send-message");
+    }
+
+    @Override
+    public void addFormatters(FormatterRegistry registry) {
+        registry.addConverter(new ZonedDateTimeConverter());
     }
 }


### PR DESCRIPTION
## 작업 내용 (Content)
- 내 페이지에서 비밀 캡슐 조회 
- 무한 스크롤 구현

## 링크 (Links)
- [JIRA 티켓 이름](https://archivetimecapsule.atlassian.net/browse/ARCH-29)
- #102 
- [noOffset Querydsl](https://jojoldu.tistory.com/528)


## 기타 사항 (Etc)
- 무한 스크롤로 구현
- page의 size의 설정과는 다른 숫자가 조회가 됨 ;; 
- native query를 확인하고 했을 때는 잘 동작함
- 캡슐 상세 보기 에서는 capsule_skin 이 실행 계획에서 const 였는데 ALL임 대체왜??? 

## Merge 전 필요 작업 (Checklist before merge)
- [ ] 잘 돌아가는지 확인, page 숫자에 따라 응답되는지 확인

## 희망 리뷰 완료 일 (Expected due date)
