### PR TITLE
fix: jwt 토큰 타입별로 구분해서 인증 및 접근 권한 부여 #123

### DIFF
--- a/backend/core/src/main/java/site/timecapsulearchive/core/domain/member/entity/Role.java
+++ b/backend/core/src/main/java/site/timecapsulearchive/core/domain/member/entity/Role.java
@@ -1,0 +1,12 @@
+package site.timecapsulearchive.core.domain.member.entity;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum Role {
+    USER("ROLE_USER"), TEMPORARY("ROLE_TEMPORARY");
+
+    private final String value;
+}

--- a/backend/core/src/main/java/site/timecapsulearchive/core/global/config/security/SecurityConfig.java
+++ b/backend/core/src/main/java/site/timecapsulearchive/core/global/config/security/SecurityConfig.java
@@ -17,11 +17,13 @@ import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
 import org.springframework.security.oauth2.client.userinfo.OAuth2UserService;
 import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.access.AccessDeniedHandler;
 import org.springframework.security.web.authentication.AuthenticationFailureHandler;
 import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
 import org.springframework.security.web.util.matcher.NegatedRequestMatcher;
 import org.springframework.security.web.util.matcher.RequestMatcher;
 import org.springframework.security.web.util.matcher.RequestMatchers;
+import site.timecapsulearchive.core.domain.member.entity.Role;
 
 @EnableWebSecurity
 @Configuration
@@ -34,6 +36,8 @@ public class SecurityConfig {
     private final AuthenticationFailureHandler oauth2LoginFailureHandler;
     private final AuthenticationProvider jwtAuthenticationProvider;
     private final ObjectMapper objectMapper;
+
+    private final AccessDeniedHandler accessDeniedHandler;
 
     @Bean
     public PasswordEncoder getPasswordEncoder() {
@@ -53,8 +57,12 @@ public class SecurityConfig {
             )
             .authorizeHttpRequests(auth -> auth
                 .requestMatchers(notRequireAuthenticationMatcher()).permitAll()
-                .anyRequest().authenticated()
-            );
+                .requestMatchers(
+                    "/auth/verification/**"
+                ).hasRole(Role.TEMPORARY.name())
+                .anyRequest().hasRole(Role.USER.name())
+            )
+            .exceptionHandling(error -> error.accessDeniedHandler(accessDeniedHandler));
 
         http.apply(
             JwtDsl.jwtDsl(

--- a/backend/core/src/main/java/site/timecapsulearchive/core/global/error/ErrorCode.java
+++ b/backend/core/src/main/java/site/timecapsulearchive/core/global/error/ErrorCode.java
@@ -18,10 +18,13 @@ public enum ErrorCode {
 
     //auth
     AUTHENTICATION_ERROR(401, "AUTH-003", "인증에 실패했습니다. 인증 수단이 유효한지 확인하세요."),
+    AUTHORIZATION_ERROR(403, "AUTH-004", "권한이 존재하지 않습니다."),
 
     //message
     TOO_MANY_REQUEST_ERROR(429, "MESSAGE-001", "너무 많은 인증 메시지를 요청했습니다. 24시간 후 요청해주세요."),
+
     CERTIFICATION_NUMBER_NOT_FOUND_ERROR(404, "MESSAGE-002", "인증 번호를 찾지 못하였습니다."),
+
     CERTIFICATION_NUMBER_NOT_MATCH_ERROR(400, "MESSAGE-003", "인증 번호가 일치하지 않습니다."),
 
     //ouath
@@ -32,7 +35,9 @@ public enum ErrorCode {
 
     //member
     LOGIN_ON_NOT_VERIFIED_ERROR(400, "MEMBER-001", "인증되지 않은 사용자로 로그인을 시도했습니다."),
+
     ALREADY_VERIFIED_ERROR(400, "MEMBER-002", "이미 인증된 사용자입니다."),
+
     MEMBER_NOT_FOUND_ERROR(404, "MEMBER-003", "사용자 데이터를 찾지 못하였습니다."),
 
     //geo

--- a/backend/core/src/main/java/site/timecapsulearchive/core/global/security/handler/CustomAccessDeniedHandler.java
+++ b/backend/core/src/main/java/site/timecapsulearchive/core/global/security/handler/CustomAccessDeniedHandler.java
@@ -1,0 +1,38 @@
+package site.timecapsulearchive.core.global.security.handler;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.stereotype.Component;
+import site.timecapsulearchive.core.global.error.ErrorCode;
+import site.timecapsulearchive.core.global.error.ErrorResponse;
+
+@Component
+@RequiredArgsConstructor
+public class CustomAccessDeniedHandler implements AccessDeniedHandler {
+
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public void handle(
+        HttpServletRequest request,
+        HttpServletResponse response,
+        AccessDeniedException accessDeniedException
+    ) throws IOException {
+
+        ErrorResponse errorResponse = ErrorResponse.create(
+            ErrorCode.AUTHORIZATION_ERROR
+        );
+
+        response.setStatus(HttpServletResponse.SC_FORBIDDEN);
+        response.setContentType(MediaType.APPLICATION_JSON_UTF8_VALUE);
+
+        response.getWriter()
+            .write(objectMapper.writeValueAsString(errorResponse));
+    }
+}

--- a/backend/core/src/main/java/site/timecapsulearchive/core/global/security/jwt/JwtAuthenticationProvider.java
+++ b/backend/core/src/main/java/site/timecapsulearchive/core/global/security/jwt/JwtAuthenticationProvider.java
@@ -1,5 +1,6 @@
 package site.timecapsulearchive.core.global.security.jwt;
 
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.authentication.AuthenticationProvider;
 import org.springframework.security.core.Authentication;
@@ -19,11 +20,20 @@ public class JwtAuthenticationProvider implements AuthenticationProvider {
 
         jwtFactory.validate(accessToken);
 
-        String memberId = jwtFactory.getSubject(
-            accessToken
+        TokenParseResult tokenParseResult = jwtFactory.parse(
+            accessToken, List.of(TokenType.ACCESS, TokenType.TEMPORARY)
         );
 
-        return JwtAuthenticationToken.authenticated(Long.valueOf(memberId));
+        Long memberId = getMemberId(tokenParseResult);
+        if (tokenParseResult.tokenType() == TokenType.TEMPORARY) {
+            return JwtAuthenticationToken.authenticatedWithTemporary(memberId);
+        }
+
+        return JwtAuthenticationToken.authenticatedWithAccess(memberId);
+    }
+
+    private Long getMemberId(TokenParseResult tokenParseResult) {
+        return Long.valueOf(tokenParseResult.subject());
     }
 
     @Override

--- a/backend/core/src/main/java/site/timecapsulearchive/core/global/security/jwt/JwtAuthenticationToken.java
+++ b/backend/core/src/main/java/site/timecapsulearchive/core/global/security/jwt/JwtAuthenticationToken.java
@@ -5,7 +5,9 @@ import java.util.Collections;
 import java.util.List;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.util.Assert;
+import site.timecapsulearchive.core.domain.member.entity.Role;
 
 public class JwtAuthenticationToken implements Authentication {
 
@@ -17,20 +19,33 @@ public class JwtAuthenticationToken implements Authentication {
     private JwtAuthenticationToken(
         String accessToken,
         Long memberId,
+        List<GrantedAuthority> authorities,
         boolean authenticated
     ) {
         this.memberId = memberId;
         this.accessToken = accessToken;
-        this.authorities = Collections.emptyList();
+        this.authorities = authorities;
         this.authenticated = authenticated;
     }
 
-    public static JwtAuthenticationToken authenticated(Long memberId) {
-        return new JwtAuthenticationToken(null, memberId, true);
+    public static JwtAuthenticationToken authenticatedWithTemporary(
+        Long memberId
+    ) {
+        return new JwtAuthenticationToken(null, memberId, getAuthorities(Role.TEMPORARY), true);
+    }
+
+    private static List<GrantedAuthority> getAuthorities(Role role) {
+        return List.of(new SimpleGrantedAuthority(role.getValue()));
+    }
+
+    public static JwtAuthenticationToken authenticatedWithAccess(
+        Long memberId
+    ) {
+        return new JwtAuthenticationToken(null, memberId, getAuthorities(Role.USER), true);
     }
 
     public static JwtAuthenticationToken unauthenticated(String accessToken) {
-        return new JwtAuthenticationToken(accessToken, null, false);
+        return new JwtAuthenticationToken(accessToken, null, Collections.emptyList(), false);
     }
 
     @Override

--- a/backend/core/src/main/java/site/timecapsulearchive/core/global/security/jwt/TokenParseResult.java
+++ b/backend/core/src/main/java/site/timecapsulearchive/core/global/security/jwt/TokenParseResult.java
@@ -1,0 +1,11 @@
+package site.timecapsulearchive.core.global.security.jwt;
+
+public record TokenParseResult(
+    String subject,
+    TokenType tokenType
+) {
+
+    public static TokenParseResult of(String subject, TokenType tokenType) {
+        return new TokenParseResult(subject, tokenType);
+    }
+}

--- a/backend/core/src/main/java/site/timecapsulearchive/core/global/security/jwt/TokenType.java
+++ b/backend/core/src/main/java/site/timecapsulearchive/core/global/security/jwt/TokenType.java
@@ -1,0 +1,5 @@
+package site.timecapsulearchive.core.global.security.jwt;
+
+public enum TokenType {
+    TEMPORARY, ACCESS, REFRESH
+}


### PR DESCRIPTION
## 작업 내용 (Content)
- 토큰의 타입별로 인증 시 검증
- 토큰의 타입별로 엔드포인트 접근 권한 부여 

## 링크 (Links)
- #123 

## 기타 사항 (Etc)
- 토큰 타입별로 검증을 통해 액세스와 템포러리는 접근 시에만, 리프레시는 재발급에만 허용
- 액세스와 템포러리는 엔드포인트 접근 시 다른 역할을 부여해 접근 제한

## Merge 전 필요 작업 (Checklist before merge)

## 희망 리뷰 완료 일 (Expected due date)
