### PR TITLE
fix : S3 응답 분리 #125

### DIFF
--- a/backend/core/src/main/java/site/timecapsulearchive/core/infra/s3/controller/S3ApiController.java
+++ b/backend/core/src/main/java/site/timecapsulearchive/core/infra/s3/controller/S3ApiController.java
@@ -28,7 +28,7 @@ public class S3ApiController implements S3Api {
         @AuthenticationPrincipal final Long memberId,
         @RequestBody @Valid final S3PreSignedUrlRequest request
     ) {
-        S3PreSignedUrlDto s3PreSignedUrlsDto = s3Service.getS3PreSignedUrls(
+        S3PreSignedUrlDto dto = s3Service.getS3PreSignedUrls(
             memberId,
             mapper.s3PreSignedUrlRequestToDto(request)
         );
@@ -36,7 +36,7 @@ public class S3ApiController implements S3Api {
         return ResponseEntity.ok(
             ApiSpec.success(
                 SuccessCode.SUCCESS,
-                S3PreSignedUrlResponse.from(s3PreSignedUrlsDto.preSignedUrls())
+                S3PreSignedUrlResponse.from(dto.preSignedImageUrls(), dto.preSignedVideoUrls())
             )
         );
     }

--- a/backend/core/src/main/java/site/timecapsulearchive/core/infra/s3/dto/S3PreSignedUrlDto.java
+++ b/backend/core/src/main/java/site/timecapsulearchive/core/infra/s3/dto/S3PreSignedUrlDto.java
@@ -2,9 +2,15 @@ package site.timecapsulearchive.core.infra.s3.dto;
 
 import java.util.List;
 
-public record S3PreSignedUrlDto(List<String> preSignedUrls) {
+public record S3PreSignedUrlDto(
+    List<String> preSignedImageUrls,
+    List<String> preSignedVideoUrls
+) {
 
-    public static S3PreSignedUrlDto from(List<String> preSignedUrls) {
-        return new S3PreSignedUrlDto(preSignedUrls);
+    public static S3PreSignedUrlDto from(
+        List<String> preSignedImageUrls,
+        List<String> preSignedVideoUrls
+    ) {
+        return new S3PreSignedUrlDto(preSignedImageUrls, preSignedVideoUrls);
     }
 }

--- a/backend/core/src/main/java/site/timecapsulearchive/core/infra/s3/dto/mapper/S3ApiMapper.java
+++ b/backend/core/src/main/java/site/timecapsulearchive/core/infra/s3/dto/mapper/S3ApiMapper.java
@@ -10,8 +10,8 @@ public class S3ApiMapper {
     public S3PreSignedUrlRequestDto s3PreSignedUrlRequestToDto(S3PreSignedUrlRequest request) {
         return S3PreSignedUrlRequestDto.from(
             request.directory(),
-            request.imageUrls(),
-            request.videoUrls()
+            request.imageNames(),
+            request.videoNames()
         );
     }
 }

--- a/backend/core/src/main/java/site/timecapsulearchive/core/infra/s3/dto/request/S3PreSignedUrlRequest.java
+++ b/backend/core/src/main/java/site/timecapsulearchive/core/infra/s3/dto/request/S3PreSignedUrlRequest.java
@@ -16,11 +16,11 @@ public record S3PreSignedUrlRequest(
 
     @Schema(description = "파일 이름들")
     @NotEmpty(message = "이미지 파일 이름은 필수 입니다.")
-    List<@Image String> imageUrls,
+    List<@Image String> imageNames,
 
     @Schema(description = "비디오 파일 이름들")
     @NotEmpty(message = "비디오 파일 이름은 필수 입니다.")
-    List<@Video String> videoUrls
+    List<@Video String> videoNames
 ) {
 
 }

--- a/backend/core/src/main/java/site/timecapsulearchive/core/infra/s3/dto/request/S3PreSignedUrlRequest.java
+++ b/backend/core/src/main/java/site/timecapsulearchive/core/infra/s3/dto/request/S3PreSignedUrlRequest.java
@@ -1,8 +1,8 @@
 package site.timecapsulearchive.core.infra.s3.dto.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.media.Schema.RequiredMode;
 import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.NotEmpty;
 import java.util.List;
 import site.timecapsulearchive.core.global.common.valid.annotation.Image;
 import site.timecapsulearchive.core.global.common.valid.annotation.Video;
@@ -14,12 +14,10 @@ public record S3PreSignedUrlRequest(
     @NotBlank(message = "디렉토리 이름은 필수 입니다.")
     String directory,
 
-    @Schema(description = "파일 이름들")
-    @NotEmpty(message = "이미지 파일 이름은 필수 입니다.")
+    @Schema(description = "파일 이름들", requiredMode = RequiredMode.NOT_REQUIRED)
     List<@Image String> imageNames,
 
-    @Schema(description = "비디오 파일 이름들")
-    @NotEmpty(message = "비디오 파일 이름은 필수 입니다.")
+    @Schema(description = "비디오 파일 이름들", requiredMode = RequiredMode.NOT_REQUIRED)
     List<@Video String> videoNames
 ) {
 

--- a/backend/core/src/main/java/site/timecapsulearchive/core/infra/s3/dto/response/S3PreSignedUrlResponse.java
+++ b/backend/core/src/main/java/site/timecapsulearchive/core/infra/s3/dto/response/S3PreSignedUrlResponse.java
@@ -6,11 +6,17 @@ import java.util.List;
 @Schema(description = "미리 서명된 s3 url 응답")
 public record S3PreSignedUrlResponse(
 
-    @Schema(description = "미리 서명된 s3 url들")
-    List<String> preSignedUrls
+    @Schema(description = "미리 서명된 이미지들의 s3 url들")
+    List<String> preSignedImageUrls,
+
+    @Schema(description = "미리 서명된 비디오들의 s3 url들")
+    List<String> preSignedVideoUrls
 ) {
 
-    public static S3PreSignedUrlResponse from(List<String> preSignedUrls) {
-        return new S3PreSignedUrlResponse(preSignedUrls);
+    public static S3PreSignedUrlResponse from(
+        List<String> preSignedImageUrls,
+        List<String> preSignedVideoUrls
+    ) {
+        return new S3PreSignedUrlResponse(preSignedImageUrls, preSignedVideoUrls);
     }
 }

--- a/backend/core/src/main/java/site/timecapsulearchive/core/infra/s3/service/S3Service.java
+++ b/backend/core/src/main/java/site/timecapsulearchive/core/infra/s3/service/S3Service.java
@@ -1,6 +1,7 @@
 package site.timecapsulearchive.core.infra.s3.service;
 
 import java.time.Duration;
+import java.util.Collections;
 import java.util.List;
 import org.springframework.stereotype.Service;
 import site.timecapsulearchive.core.infra.s3.config.S3Config;
@@ -39,7 +40,18 @@ public class S3Service {
         final Long memberId,
         final S3PreSignedUrlRequestDto dto
     ) {
-        List<String> preSignedImageUrls = dto.imageUrls()
+        return S3PreSignedUrlDto.from(
+            getPreSignedImageUrls(memberId, dto),
+            getPreSignedVideoUrls(memberId, dto)
+        );
+    }
+
+    private List<String> getPreSignedImageUrls(Long memberId, S3PreSignedUrlRequestDto dto) {
+        if (dto.imageUrls() == null || dto.imageUrls().isEmpty()) {
+            return Collections.emptyList();
+        }
+
+        return dto.imageUrls()
             .stream()
             .map(fileName -> createS3PreSignedUrl(
                 memberId,
@@ -48,8 +60,14 @@ public class S3Service {
                 IMAGE_CONTENT_TYPE
             ))
             .toList();
+    }
 
-        List<String> preSignedVideoUrls = dto.videoUrls()
+    private List<String> getPreSignedVideoUrls(Long memberId, S3PreSignedUrlRequestDto dto) {
+        if (dto.videoUrls() == null || dto.videoUrls().isEmpty()) {
+            return Collections.emptyList();
+        }
+
+        return dto.videoUrls()
             .stream()
             .map(fileName -> createS3PreSignedUrl(
                 memberId,
@@ -58,11 +76,6 @@ public class S3Service {
                 VIDEO_CONTENT_TYPE
             ))
             .toList();
-
-        return S3PreSignedUrlDto.from(
-            preSignedImageUrls,
-            preSignedVideoUrls
-        );
     }
 
     private String createS3PreSignedUrl(

--- a/backend/core/src/main/java/site/timecapsulearchive/core/infra/s3/service/S3Service.java
+++ b/backend/core/src/main/java/site/timecapsulearchive/core/infra/s3/service/S3Service.java
@@ -1,7 +1,7 @@
 package site.timecapsulearchive.core.infra.s3.service;
 
 import java.time.Duration;
-import java.util.stream.Stream;
+import java.util.List;
 import org.springframework.stereotype.Service;
 import site.timecapsulearchive.core.infra.s3.config.S3Config;
 import site.timecapsulearchive.core.infra.s3.dto.S3PreSignedUrlDto;
@@ -39,27 +39,29 @@ public class S3Service {
         final Long memberId,
         final S3PreSignedUrlRequestDto dto
     ) {
-        Stream<String> imageUrlStream = dto.imageUrls()
+        List<String> preSignedImageUrls = dto.imageUrls()
             .stream()
             .map(fileName -> createS3PreSignedUrl(
                 memberId,
                 dto.directory(),
                 fileName,
                 IMAGE_CONTENT_TYPE
-            ));
+            ))
+            .toList();
 
-        Stream<String> videoUrlStream = dto.videoUrls()
+        List<String> preSignedVideoUrls = dto.videoUrls()
             .stream()
             .map(fileName -> createS3PreSignedUrl(
                 memberId,
                 dto.directory(),
                 fileName,
                 VIDEO_CONTENT_TYPE
-            ));
+            ))
+            .toList();
 
         return S3PreSignedUrlDto.from(
-            Stream.concat(imageUrlStream, videoUrlStream)
-                .toList()
+            preSignedImageUrls,
+            preSignedVideoUrls
         );
     }
 


### PR DESCRIPTION
## 작업 내용 (Content)
- 서명된 s3 url 응답을 기존의 하나에서 이미지 url과 비디오 url로 분리
- request nullable 핸들링

## 링크 (Links)
- #125 

## 기타 사항 (Etc)

## Merge 전 필요 작업 (Checklist before merge)

## 희망 리뷰 완료 일 (Expected due date)
