### PR TITLE
fix : 주소록 기반 친구 조회, 태그 조회 응답 타입 수정

### DIFF
--- a/backend/core/src/main/java/site/timecapsulearchive/core/domain/friend/api/FriendApi.java
+++ b/backend/core/src/main/java/site/timecapsulearchive/core/domain/friend/api/FriendApi.java
@@ -14,8 +14,8 @@ import site.timecapsulearchive.core.domain.friend.data.reqeust.SearchFriendsRequ
 import site.timecapsulearchive.core.domain.friend.data.response.FriendReqStatusResponse;
 import site.timecapsulearchive.core.domain.friend.data.response.FriendRequestsSliceResponse;
 import site.timecapsulearchive.core.domain.friend.data.response.FriendsSliceResponse;
-import site.timecapsulearchive.core.domain.friend.data.response.SearchFriendSummaryResponse;
 import site.timecapsulearchive.core.domain.friend.data.response.SearchFriendsResponse;
+import site.timecapsulearchive.core.domain.friend.data.response.SearchTagFriendSummaryResponse;
 import site.timecapsulearchive.core.global.common.response.ApiSpec;
 import site.timecapsulearchive.core.global.error.ErrorResponse;
 
@@ -189,7 +189,7 @@ public interface FriendApi {
             description = "ok"
         )
     })
-    ResponseEntity<ApiSpec<SearchFriendSummaryResponse>> searchFriendByTag(
+    ResponseEntity<ApiSpec<SearchTagFriendSummaryResponse>> searchFriendByTag(
         Long memberId,
 
         @Parameter(in = ParameterIn.QUERY, description = "친구 태그", required = true)

--- a/backend/core/src/main/java/site/timecapsulearchive/core/domain/friend/api/FriendApiController.java
+++ b/backend/core/src/main/java/site/timecapsulearchive/core/domain/friend/api/FriendApiController.java
@@ -17,8 +17,8 @@ import site.timecapsulearchive.core.domain.friend.data.reqeust.SearchFriendsRequ
 import site.timecapsulearchive.core.domain.friend.data.response.FriendReqStatusResponse;
 import site.timecapsulearchive.core.domain.friend.data.response.FriendRequestsSliceResponse;
 import site.timecapsulearchive.core.domain.friend.data.response.FriendsSliceResponse;
-import site.timecapsulearchive.core.domain.friend.data.response.SearchFriendSummaryResponse;
 import site.timecapsulearchive.core.domain.friend.data.response.SearchFriendsResponse;
+import site.timecapsulearchive.core.domain.friend.data.response.SearchTagFriendSummaryResponse;
 import site.timecapsulearchive.core.domain.friend.service.FriendService;
 import site.timecapsulearchive.core.global.common.response.ApiSpec;
 import site.timecapsulearchive.core.global.common.response.SuccessCode;
@@ -134,7 +134,7 @@ public class FriendApiController implements FriendApi {
 
     @GetMapping(value = "/search")
     @Override
-    public ResponseEntity<ApiSpec<SearchFriendSummaryResponse>> searchFriendByTag(
+    public ResponseEntity<ApiSpec<SearchTagFriendSummaryResponse>> searchFriendByTag(
         @AuthenticationPrincipal Long memberId,
         @RequestParam(value = "friend-tag") final String tag
     ) {

--- a/backend/core/src/main/java/site/timecapsulearchive/core/domain/friend/data/dto/SearchFriendSummaryDto.java
+++ b/backend/core/src/main/java/site/timecapsulearchive/core/domain/friend/data/dto/SearchFriendSummaryDto.java
@@ -4,6 +4,7 @@ public record SearchFriendSummaryDto(
     Long id,
     String profileUrl,
     String nickname,
+    byte[] phone,
     Boolean isFriend,
     Boolean isFriendRequest
 ) {

--- a/backend/core/src/main/java/site/timecapsulearchive/core/domain/friend/data/dto/SearchFriendSummaryDto.java
+++ b/backend/core/src/main/java/site/timecapsulearchive/core/domain/friend/data/dto/SearchFriendSummaryDto.java
@@ -4,7 +4,8 @@ public record SearchFriendSummaryDto(
     Long id,
     String profileUrl,
     String nickname,
-    Boolean isFriend
+    Boolean isFriend,
+    Boolean isFriendRequest
 ) {
 
 }

--- a/backend/core/src/main/java/site/timecapsulearchive/core/domain/friend/data/dto/SearchTagFriendSummaryDto.java
+++ b/backend/core/src/main/java/site/timecapsulearchive/core/domain/friend/data/dto/SearchTagFriendSummaryDto.java
@@ -1,0 +1,23 @@
+package site.timecapsulearchive.core.domain.friend.data.dto;
+
+import site.timecapsulearchive.core.domain.friend.data.response.SearchTagFriendSummaryResponse;
+
+public record SearchTagFriendSummaryDto(
+    Long id,
+    String profileUrl,
+    String nickname,
+    Boolean isFriend,
+    Boolean isFriendRequest
+) {
+
+    public SearchTagFriendSummaryResponse toResponse() {
+        return SearchTagFriendSummaryResponse.builder()
+            .id(id)
+            .profileUrl(profileUrl)
+            .nickname(nickname)
+            .isFriend(isFriend)
+            .isFriendRequest(isFriendRequest)
+            .build();
+    }
+
+}

--- a/backend/core/src/main/java/site/timecapsulearchive/core/domain/friend/data/mapper/MemberFriendMapper.java
+++ b/backend/core/src/main/java/site/timecapsulearchive/core/domain/friend/data/mapper/MemberFriendMapper.java
@@ -1,6 +1,7 @@
 package site.timecapsulearchive.core.domain.friend.data.mapper;
 
 import java.util.List;
+import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Component;
 import site.timecapsulearchive.core.domain.friend.data.dto.FriendSummaryDto;
@@ -10,9 +11,13 @@ import site.timecapsulearchive.core.domain.friend.data.response.FriendSummaryRes
 import site.timecapsulearchive.core.domain.friend.data.response.FriendsSliceResponse;
 import site.timecapsulearchive.core.domain.friend.data.response.SearchFriendSummaryResponse;
 import site.timecapsulearchive.core.domain.friend.data.response.SearchFriendsResponse;
+import site.timecapsulearchive.core.global.security.encryption.AESEncryptionManager;
 
 @Component
+@RequiredArgsConstructor
 public class MemberFriendMapper {
+
+    private final AESEncryptionManager aesEncryptionManager;
 
     public FriendsSliceResponse friendsSliceToResponse(final Slice<FriendSummaryDto> slice) {
         final List<FriendSummaryResponse> friends = slice.getContent()
@@ -57,6 +62,7 @@ public class MemberFriendMapper {
             .id(dto.id())
             .profileUrl(dto.profileUrl())
             .nickname(dto.nickname())
+            .phone(aesEncryptionManager.decryptWithPrefixIV(dto.phone()))
             .isFriend(dto.isFriend())
             .isFriendRequest(dto.isFriendRequest())
             .build();

--- a/backend/core/src/main/java/site/timecapsulearchive/core/domain/friend/data/mapper/MemberFriendMapper.java
+++ b/backend/core/src/main/java/site/timecapsulearchive/core/domain/friend/data/mapper/MemberFriendMapper.java
@@ -58,6 +58,7 @@ public class MemberFriendMapper {
             .profileUrl(dto.profileUrl())
             .nickname(dto.nickname())
             .isFriend(dto.isFriend())
+            .isFriendRequest(dto.isFriendRequest())
             .build();
     }
 }

--- a/backend/core/src/main/java/site/timecapsulearchive/core/domain/friend/data/response/SearchFriendSummaryResponse.java
+++ b/backend/core/src/main/java/site/timecapsulearchive/core/domain/friend/data/response/SearchFriendSummaryResponse.java
@@ -16,6 +16,9 @@ public record SearchFriendSummaryResponse(
     @Schema(description = "검색된 사용자 닉네임")
     String nickname,
 
+    @Schema(description = "친구 전화번호")
+    String phone,
+
     @Schema(description = "친구 유무")
     Boolean isFriend,
 

--- a/backend/core/src/main/java/site/timecapsulearchive/core/domain/friend/data/response/SearchFriendSummaryResponse.java
+++ b/backend/core/src/main/java/site/timecapsulearchive/core/domain/friend/data/response/SearchFriendSummaryResponse.java
@@ -17,7 +17,11 @@ public record SearchFriendSummaryResponse(
     String nickname,
 
     @Schema(description = "친구 유무")
-    Boolean isFriend
+    Boolean isFriend,
+
+    @Schema(description = "친구 요청 유무")
+    Boolean isFriendRequest
+
 ) {
 
 }

--- a/backend/core/src/main/java/site/timecapsulearchive/core/domain/friend/data/response/SearchTagFriendSummaryResponse.java
+++ b/backend/core/src/main/java/site/timecapsulearchive/core/domain/friend/data/response/SearchTagFriendSummaryResponse.java
@@ -1,0 +1,27 @@
+package site.timecapsulearchive.core.domain.friend.data.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+
+@Builder
+@Schema(description = "검색된 친구 정보")
+public record SearchTagFriendSummaryResponse(
+
+    @Schema(description = "검색된 사용자 아이디")
+    Long id,
+
+    @Schema(description = "검색된 사용자 프로필")
+    String profileUrl,
+
+    @Schema(description = "검색된 사용자 닉네임")
+    String nickname,
+
+    @Schema(description = "친구 유무")
+    Boolean isFriend,
+
+    @Schema(description = "친구 요청 유무")
+    Boolean isFriendRequest
+
+) {
+
+}

--- a/backend/core/src/main/java/site/timecapsulearchive/core/domain/friend/repository/MemberFriendQueryRepository.java
+++ b/backend/core/src/main/java/site/timecapsulearchive/core/domain/friend/repository/MemberFriendQueryRepository.java
@@ -122,12 +122,15 @@ public class MemberFriendQueryRepository {
                     member.id,
                     member.profileUrl,
                     member.nickname,
-                    memberFriend.id.isNotNull()
+                    memberFriend.id.isNotNull(),
+                    friendInvite.id.isNotNull()
                 )
             )
             .from(member)
             .leftJoin(memberFriend)
             .on(memberFriend.friend.id.eq(member.id).and(memberFriend.owner.id.eq(memberId)))
+            .leftJoin(friendInvite)
+            .on(friendInvite.friend.id.eq(member.id).and(memberFriend.owner.id.eq(memberId)))
             .where(member.tag.eq(tag))
             .fetchOne()
         );

--- a/backend/core/src/main/java/site/timecapsulearchive/core/domain/friend/repository/MemberFriendQueryRepository.java
+++ b/backend/core/src/main/java/site/timecapsulearchive/core/domain/friend/repository/MemberFriendQueryRepository.java
@@ -101,12 +101,16 @@ public class MemberFriendQueryRepository {
                     member.id,
                     member.profileUrl,
                     member.nickname,
-                    memberFriend.id.isNotNull()
+                    member.phone,
+                    memberFriend.id.isNotNull(),
+                    friendInvite.id.isNotNull()
                 )
             )
             .from(member)
             .leftJoin(memberFriend)
             .on(memberFriend.friend.id.eq(member.id).and(memberFriend.owner.id.eq(memberId)))
+            .leftJoin(friendInvite)
+            .on(friendInvite.friend.id.eq(member.id).and(memberFriend.owner.id.eq(memberId)))
             .where(member.phone_hash.in(hashes))
             .fetch();
     }
@@ -122,6 +126,7 @@ public class MemberFriendQueryRepository {
                     member.id,
                     member.profileUrl,
                     member.nickname,
+                    member.phone,
                     memberFriend.id.isNotNull(),
                     friendInvite.id.isNotNull()
                 )

--- a/backend/core/src/main/java/site/timecapsulearchive/core/domain/friend/repository/MemberFriendQueryRepository.java
+++ b/backend/core/src/main/java/site/timecapsulearchive/core/domain/friend/repository/MemberFriendQueryRepository.java
@@ -16,6 +16,7 @@ import org.springframework.data.domain.SliceImpl;
 import org.springframework.stereotype.Repository;
 import site.timecapsulearchive.core.domain.friend.data.dto.FriendSummaryDto;
 import site.timecapsulearchive.core.domain.friend.data.dto.SearchFriendSummaryDto;
+import site.timecapsulearchive.core.domain.friend.data.dto.SearchTagFriendSummaryDto;
 import site.timecapsulearchive.core.domain.friend.entity.FriendStatus;
 
 @Repository
@@ -115,18 +116,17 @@ public class MemberFriendQueryRepository {
             .fetch();
     }
 
-    public Optional<SearchFriendSummaryDto> findFriendsByTag(
+    public Optional<SearchTagFriendSummaryDto> findFriendsByTag(
         final Long memberId,
         final String tag
     ) {
         return Optional.ofNullable(jpaQueryFactory
             .select(
                 Projections.constructor(
-                    SearchFriendSummaryDto.class,
+                    SearchTagFriendSummaryDto.class,
                     member.id,
                     member.profileUrl,
                     member.nickname,
-                    member.phone,
                     memberFriend.id.isNotNull(),
                     friendInvite.id.isNotNull()
                 )

--- a/backend/core/src/main/java/site/timecapsulearchive/core/domain/friend/service/FriendService.java
+++ b/backend/core/src/main/java/site/timecapsulearchive/core/domain/friend/service/FriendService.java
@@ -12,13 +12,14 @@ import org.springframework.transaction.support.TransactionCallbackWithoutResult;
 import org.springframework.transaction.support.TransactionTemplate;
 import site.timecapsulearchive.core.domain.friend.data.dto.FriendSummaryDto;
 import site.timecapsulearchive.core.domain.friend.data.dto.SearchFriendSummaryDto;
+import site.timecapsulearchive.core.domain.friend.data.dto.SearchTagFriendSummaryDto;
 import site.timecapsulearchive.core.domain.friend.data.mapper.FriendMapper;
 import site.timecapsulearchive.core.domain.friend.data.mapper.MemberFriendMapper;
 import site.timecapsulearchive.core.domain.friend.data.response.FriendReqStatusResponse;
 import site.timecapsulearchive.core.domain.friend.data.response.FriendRequestsSliceResponse;
 import site.timecapsulearchive.core.domain.friend.data.response.FriendsSliceResponse;
-import site.timecapsulearchive.core.domain.friend.data.response.SearchFriendSummaryResponse;
 import site.timecapsulearchive.core.domain.friend.data.response.SearchFriendsResponse;
+import site.timecapsulearchive.core.domain.friend.data.response.SearchTagFriendSummaryResponse;
 import site.timecapsulearchive.core.domain.friend.entity.FriendInvite;
 import site.timecapsulearchive.core.domain.friend.entity.MemberFriend;
 import site.timecapsulearchive.core.domain.friend.exception.DuplicateFriendIdException;
@@ -174,10 +175,10 @@ public class FriendService {
     }
 
     @Transactional(readOnly = true)
-    public SearchFriendSummaryResponse searchFriend(final Long memberId, final String tag) {
-        final SearchFriendSummaryDto friendSummaryDto = memberFriendQueryRepository
+    public SearchTagFriendSummaryResponse searchFriend(final Long memberId, final String tag) {
+        final SearchTagFriendSummaryDto friendSummaryDto = memberFriendQueryRepository
             .findFriendsByTag(memberId, tag).orElseThrow(FriendNotFoundException::new);
 
-        return memberFriendMapper.searchFriendSummaryDtoToResponse(friendSummaryDto);
+        return friendSummaryDto.toResponse();
     }
 }

--- a/backend/core/src/test/java/site/timecapsulearchive/core/domain/friend/repository/MemberFriendQueryRepositoryTest.java
+++ b/backend/core/src/test/java/site/timecapsulearchive/core/domain/friend/repository/MemberFriendQueryRepositoryTest.java
@@ -28,6 +28,7 @@ import site.timecapsulearchive.core.common.fixture.MemberFixture;
 import site.timecapsulearchive.core.common.fixture.MemberFriendFixture;
 import site.timecapsulearchive.core.domain.friend.data.dto.FriendSummaryDto;
 import site.timecapsulearchive.core.domain.friend.data.dto.SearchFriendSummaryDto;
+import site.timecapsulearchive.core.domain.friend.data.dto.SearchTagFriendSummaryDto;
 import site.timecapsulearchive.core.domain.friend.entity.FriendInvite;
 import site.timecapsulearchive.core.domain.friend.entity.MemberFriend;
 import site.timecapsulearchive.core.domain.member.entity.Member;
@@ -263,7 +264,7 @@ class MemberFriendQueryRepositoryTest extends RepositoryTest {
     @ValueSource(ints = {20, 15, 10, 5})
     void 사용자_아이디와_친구_태그로_친구관계를_조회하면_친구인_경우_True를_반환한다(int friendId) {
         //given
-        Optional<SearchFriendSummaryDto> dto = memberFriendQueryRepository.findFriendsByTag(
+        Optional<SearchTagFriendSummaryDto> dto = memberFriendQueryRepository.findFriendsByTag(
             owner.getId(), friendId + "testTag");
 
         //when
@@ -277,7 +278,7 @@ class MemberFriendQueryRepositoryTest extends RepositoryTest {
     @ValueSource(ints = {30, 28, 25, 21})
     void 사용자_아이디와_친구_태그로_친구관계를_조회하면_친구가_아닌_경우_False를_반환한다(int friendId) {
         //given
-        Optional<SearchFriendSummaryDto> dto = memberFriendQueryRepository.findFriendsByTag(
+        Optional<SearchTagFriendSummaryDto> dto = memberFriendQueryRepository.findFriendsByTag(
             owner.getId(), friendId + "testTag");
 
         //when

--- a/backend/core/src/test/java/site/timecapsulearchive/core/domain/friend/service/FriendServiceTest.java
+++ b/backend/core/src/test/java/site/timecapsulearchive/core/domain/friend/service/FriendServiceTest.java
@@ -11,6 +11,7 @@ import java.util.Collections;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.springframework.transaction.PlatformTransactionManager;
+import site.timecapsulearchive.core.common.fixture.MemberFixture;
 import site.timecapsulearchive.core.domain.friend.data.dto.SearchFriendSummaryDto;
 import site.timecapsulearchive.core.domain.friend.data.mapper.FriendMapper;
 import site.timecapsulearchive.core.domain.friend.data.mapper.MemberFriendMapper;
@@ -19,13 +20,15 @@ import site.timecapsulearchive.core.domain.friend.repository.FriendInviteReposit
 import site.timecapsulearchive.core.domain.friend.repository.MemberFriendQueryRepository;
 import site.timecapsulearchive.core.domain.friend.repository.MemberFriendRepository;
 import site.timecapsulearchive.core.domain.member.repository.MemberRepository;
+import site.timecapsulearchive.core.global.security.encryption.AESEncryptionManager;
 import site.timecapsulearchive.core.global.security.encryption.HashEncryptionManager;
 import site.timecapsulearchive.core.global.security.encryption.HashProperties;
 import site.timecapsulearchive.core.infra.notification.manager.NotificationManager;
 
 class FriendServiceTest {
 
-    private final MemberFriendMapper memberFriendMapper = new MemberFriendMapper();
+    private final MemberFriendMapper memberFriendMapper = new MemberFriendMapper(mock(
+        AESEncryptionManager.class));
     private final MemberFriendQueryRepository memberFriendQueryRepository = mock(
         MemberFriendQueryRepository.class);
     private final MemberFriendRepository memberFriendRepository = mock(
@@ -84,7 +87,7 @@ class FriendServiceTest {
         List<SearchFriendSummaryDto> result = new ArrayList<>();
         for (long i = 0; i < 8; i++) {
             result.add(new SearchFriendSummaryDto(i, i + "testProfile.com", i + "testNickname",
-                Boolean.TRUE));
+                MemberFixture.getPhoneBytes((int)i), Boolean.TRUE, Boolean.FALSE));
         }
 
         return result;


### PR DESCRIPTION
## 작업 내용 (Content)
- 주소록 기반 친구조회 : 내 전화번호 (목록 번호, 받은 이름), 친구 요청 유무 추가
- 태그 조회 : 친구 요청 유무 추가

## 링크 (Links)

- [API 스펙 문서](https://github.com/tukcomCD2024/DroidBlossom/issues/320)


## 기타 사항 (Etc)
- 두 조회의 응답 타입이 같으므로, 둘다 같은 응답 형식의 데이터들을 반환하게 함 

@Schema(description = "검색된 사용자 아이디")
Long id,

@Schema(description = "검색된 사용자 프로필")
String profileUrl,

@Schema(description = "검색된 사용자 닉네임")
String nickname,

@Schema(description = "친구 전화번호")
String phone,

@Schema(description = "친구 유무")
Boolean isFriend,

@Schema(description = "친구 요청 유무")
Boolean isFriendRequest

## Merge 전 필요 작업 (Checklist before merge)
- [ ] 예) XX 테이블 추가, 앱 배포 등
- [ ] eg) Create XX table, Deploy app etc

## 희망 리뷰 완료 일 (Expected due date)
202X. X. X. Wed
