### PR TITLE
Arch 159 b feat/create group capsule

### DIFF
--- a/backend/core/src/main/java/site/timecapsulearchive/core/domain/capsule/entity/Capsule.java
+++ b/backend/core/src/main/java/site/timecapsulearchive/core/domain/capsule/entity/Capsule.java
@@ -89,7 +89,8 @@ public class Capsule extends BaseEntity {
         Address address,
         Point point,
         Member member,
-        CapsuleSkin capsuleSkin
+        CapsuleSkin capsuleSkin,
+        Group group
     ) {
         this.dueDate = dueDate;
         this.title = title;
@@ -98,7 +99,7 @@ public class Capsule extends BaseEntity {
         this.type = type;
         this.isOpened = Boolean.FALSE;
         this.address = address;
-        this.group = null;
+        this.group = group;
         this.member = member;
         this.capsuleSkin = capsuleSkin;
     }

--- a/backend/core/src/main/java/site/timecapsulearchive/core/domain/capsule/entity/Image.java
+++ b/backend/core/src/main/java/site/timecapsulearchive/core/domain/capsule/entity/Image.java
@@ -9,6 +9,7 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
+import java.util.List;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -43,5 +44,11 @@ public class Image extends BaseEntity {
         this.imageUrl = imageUrl;
         this.capsule = capsule;
         this.member = member;
+    }
+
+    public static List<Image> createOf(List<String> imageUrls, Capsule capsule, Member member) {
+        return imageUrls.stream()
+            .map(url -> new Image(url, capsule, member))
+            .toList();
     }
 }

--- a/backend/core/src/main/java/site/timecapsulearchive/core/domain/capsule/entity/Video.java
+++ b/backend/core/src/main/java/site/timecapsulearchive/core/domain/capsule/entity/Video.java
@@ -9,6 +9,7 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
+import java.util.List;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -43,5 +44,11 @@ public class Video extends BaseEntity {
         this.videoUrl = videoUrl;
         this.capsule = capsule;
         this.member = member;
+    }
+
+    public static List<Video> createOf(List<String> urls, Capsule capsule, Member member) {
+        return urls.stream()
+            .map(url -> new Video(url, capsule, member))
+            .toList();
     }
 }

--- a/backend/core/src/main/java/site/timecapsulearchive/core/domain/capsule/facade/GroupCapsuleFacade.java
+++ b/backend/core/src/main/java/site/timecapsulearchive/core/domain/capsule/facade/GroupCapsuleFacade.java
@@ -1,0 +1,50 @@
+package site.timecapsulearchive.core.domain.capsule.facade;
+
+import lombok.RequiredArgsConstructor;
+import org.locationtech.jts.geom.Point;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+import site.timecapsulearchive.core.domain.capsule.entity.Capsule;
+import site.timecapsulearchive.core.domain.capsule.group_capsule.data.dto.GroupCapsuleCreateRequestDto;
+import site.timecapsulearchive.core.domain.capsule.group_capsule.service.GroupCapsuleService;
+import site.timecapsulearchive.core.domain.capsule.service.ImageService;
+import site.timecapsulearchive.core.domain.capsule.service.VideoService;
+import site.timecapsulearchive.core.domain.capsuleskin.entity.CapsuleSkin;
+import site.timecapsulearchive.core.domain.capsuleskin.service.CapsuleSkinService;
+import site.timecapsulearchive.core.domain.group.entity.Group;
+import site.timecapsulearchive.core.domain.group.service.GroupService;
+import site.timecapsulearchive.core.domain.member.entity.Member;
+import site.timecapsulearchive.core.domain.member.service.MemberService;
+import site.timecapsulearchive.core.global.geography.GeoTransformManager;
+
+@Component
+@RequiredArgsConstructor
+public class GroupCapsuleFacade {
+
+    private final MemberService memberService;
+    private final GroupCapsuleService groupCapsuleService;
+    private final GroupService groupService;
+    private final ImageService imageService;
+    private final VideoService videoService;
+    private final GeoTransformManager geoTransformManager;
+    private final CapsuleSkinService capsuleSkinService;
+
+    @Transactional
+    public void saveGroupCapsule(
+        GroupCapsuleCreateRequestDto dto,
+        Long memberId,
+        Long groupId
+    ) {
+        Member member = memberService.findMemberById(memberId);
+        Group group = groupService.findGroupById(groupId);
+        CapsuleSkin capsuleSkin = capsuleSkinService.findCapsuleSkinById(dto.capsuleSkinId());
+
+        Point point = geoTransformManager.changePoint4326To3857(dto.latitude(), dto.longitude());
+
+        Capsule capsule = groupCapsuleService.saveGroupCapsule(dto, member, group, capsuleSkin,
+            point);
+
+        imageService.bulkSave(dto.imageNames(), capsule, member);
+        videoService.bulkSave(dto.imageNames(), capsule, member);
+    }
+}

--- a/backend/core/src/main/java/site/timecapsulearchive/core/domain/capsule/group_capsule/api/GroupCapsuleApi.java
+++ b/backend/core/src/main/java/site/timecapsulearchive/core/domain/capsule/group_capsule/api/GroupCapsuleApi.java
@@ -3,6 +3,7 @@ package site.timecapsulearchive.core.domain.capsule.group_capsule.api;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
@@ -21,6 +22,7 @@ import site.timecapsulearchive.core.domain.capsule.group_capsule.data.response.G
 import site.timecapsulearchive.core.domain.capsule.group_capsule.data.response.GroupCapsulePageResponse;
 import site.timecapsulearchive.core.domain.capsule.group_capsule.data.response.GroupCapsuleSummaryResponse;
 import site.timecapsulearchive.core.global.common.response.ApiSpec;
+import site.timecapsulearchive.core.global.error.ErrorResponse;
 
 
 public interface GroupCapsuleApi {
@@ -33,14 +35,26 @@ public interface GroupCapsuleApi {
     )
     @ApiResponses(value = {
         @ApiResponse(
-            responseCode = "202",
-            description = "처리 시작"
+            responseCode = "200",
+            description = "처리 완료"
+        ),
+        @ApiResponse(
+            responseCode = "404",
+            description = """
+                요청이 잘못되어 발생하는 오류이다.
+                <ul>
+                <li>회원을 찾을 수 없는 경우 발생한다.</li>
+                <li>캡슐 스킨을 찾을 수 없는 경우 발생한다.</li>
+                <li>그룹을 찾을 수 없는 경우 발생한다.</li>
+                </ul>
+                """,
+            content = @Content(schema = @Schema(implementation = ErrorResponse.class))
         )
     })
     ResponseEntity<ApiSpec<String>> createGroupCapsule(
         Long memberId,
 
-        @Parameter(in = ParameterIn.PATH, description = "생성할 그룹 아이디", required = true, schema = @Schema())
+        @Parameter(in = ParameterIn.PATH, description = "생성할 그룹 아이디", required = true)
         Long groupId,
 
         GroupCapsuleCreateRequest request

--- a/backend/core/src/main/java/site/timecapsulearchive/core/domain/capsule/group_capsule/api/GroupCapsuleApi.java
+++ b/backend/core/src/main/java/site/timecapsulearchive/core/domain/capsule/group_capsule/api/GroupCapsuleApi.java
@@ -14,13 +14,13 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import site.timecapsulearchive.core.domain.capsule.group_capsule.data.reqeust.GroupCapsuleCreateRequest;
 import site.timecapsulearchive.core.domain.capsule.group_capsule.data.reqeust.GroupCapsuleUpdateRequest;
 import site.timecapsulearchive.core.domain.capsule.group_capsule.data.response.GroupCapsuleDetailResponse;
 import site.timecapsulearchive.core.domain.capsule.group_capsule.data.response.GroupCapsulePageResponse;
 import site.timecapsulearchive.core.domain.capsule.group_capsule.data.response.GroupCapsuleSummaryResponse;
+import site.timecapsulearchive.core.global.common.response.ApiSpec;
 
 
 public interface GroupCapsuleApi {
@@ -37,15 +37,13 @@ public interface GroupCapsuleApi {
             description = "처리 시작"
         )
     })
-    @PostMapping(
-        value = "/groups/{group_id}/capsules",
-        consumes = {"multipart/form-data"}
-    )
-    ResponseEntity<GroupCapsuleSummaryResponse> createGroupCapsule(
-        @Parameter(in = ParameterIn.PATH, description = "생성할 그룹 아이디", required = true, schema = @Schema())
-        @PathVariable("group_id") Long groupId,
+    ResponseEntity<ApiSpec<String>> createGroupCapsule(
+        Long memberId,
 
-        @ModelAttribute GroupCapsuleCreateRequest request
+        @Parameter(in = ParameterIn.PATH, description = "생성할 그룹 아이디", required = true, schema = @Schema())
+        Long groupId,
+
+        GroupCapsuleCreateRequest request
     );
 
     @Operation(

--- a/backend/core/src/main/java/site/timecapsulearchive/core/domain/capsule/group_capsule/api/GroupCapsuleApiController.java
+++ b/backend/core/src/main/java/site/timecapsulearchive/core/domain/capsule/group_capsule/api/GroupCapsuleApiController.java
@@ -1,0 +1,63 @@
+package site.timecapsulearchive.core.domain.capsule.group_capsule.api;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import site.timecapsulearchive.core.domain.capsule.facade.GroupCapsuleFacade;
+import site.timecapsulearchive.core.domain.capsule.group_capsule.data.reqeust.GroupCapsuleCreateRequest;
+import site.timecapsulearchive.core.domain.capsule.group_capsule.data.reqeust.GroupCapsuleUpdateRequest;
+import site.timecapsulearchive.core.domain.capsule.group_capsule.data.response.GroupCapsuleDetailResponse;
+import site.timecapsulearchive.core.domain.capsule.group_capsule.data.response.GroupCapsulePageResponse;
+import site.timecapsulearchive.core.domain.capsule.group_capsule.data.response.GroupCapsuleSummaryResponse;
+import site.timecapsulearchive.core.global.common.response.ApiSpec;
+import site.timecapsulearchive.core.global.common.response.SuccessCode;
+
+@RestController
+@RequestMapping("/group")
+@RequiredArgsConstructor
+public class GroupCapsuleApiController implements GroupCapsuleApi {
+
+    private final GroupCapsuleFacade groupCapsuleFacade;
+
+    @PostMapping(
+        value = "/{group_id}/capsules",
+        consumes = {"application/json"}
+    )
+    @Override
+    public ResponseEntity<ApiSpec<String>> createGroupCapsule(
+        @AuthenticationPrincipal Long memberId,
+        @PathVariable("group_id") Long groupId,
+        @Valid @RequestBody GroupCapsuleCreateRequest request
+    ) {
+        groupCapsuleFacade.saveGroupCapsule(request.toGroupCapsuleCreateRequestDto(),
+            memberId, groupId);
+
+        return ResponseEntity.ok(
+            ApiSpec.empty(SuccessCode.SUCCESS)
+        );
+    }
+
+    @Override
+    public ResponseEntity<GroupCapsuleDetailResponse> findGroupCapsuleByIdAndGroupId(Long groupId,
+        Long capsuleId) {
+        return null;
+    }
+
+    @Override
+    public ResponseEntity<GroupCapsulePageResponse> getGroupCapsules(Long groupId, Long size,
+        Long capsuleId) {
+        return null;
+    }
+
+    @Override
+    public ResponseEntity<GroupCapsuleSummaryResponse> updateGroupCapsuleByIdAndGroupId(
+        Long groupId, Long capsuleId, GroupCapsuleUpdateRequest request) {
+        return null;
+    }
+}

--- a/backend/core/src/main/java/site/timecapsulearchive/core/domain/capsule/group_capsule/data/dto/GroupCapsuleCreateRequestDto.java
+++ b/backend/core/src/main/java/site/timecapsulearchive/core/domain/capsule/group_capsule/data/dto/GroupCapsuleCreateRequestDto.java
@@ -1,0 +1,46 @@
+package site.timecapsulearchive.core.domain.capsule.group_capsule.data.dto;
+
+import java.time.ZonedDateTime;
+import java.util.List;
+import lombok.Builder;
+import org.locationtech.jts.geom.Point;
+import site.timecapsulearchive.core.domain.capsule.entity.Capsule;
+import site.timecapsulearchive.core.domain.capsule.entity.CapsuleType;
+import site.timecapsulearchive.core.domain.capsuleskin.entity.CapsuleSkin;
+import site.timecapsulearchive.core.domain.group.entity.Group;
+import site.timecapsulearchive.core.domain.member.entity.Member;
+import site.timecapsulearchive.core.infra.map.data.dto.AddressData;
+
+@Builder
+public record GroupCapsuleCreateRequestDto(
+    List<String> imageNames,
+    List<String> videoNames,
+    Long capsuleSkinId,
+    String title,
+    String content,
+    Double longitude,
+    Double latitude,
+    AddressData addressData,
+    ZonedDateTime dueDate
+) {
+
+    public Capsule toGroupCapsule(
+        Member member,
+        CapsuleSkin capsuleSkin,
+        Group group,
+        CapsuleType capsuleType,
+        Point point
+    ) {
+        return Capsule.builder()
+            .title(title)
+            .content(content)
+            .point(point)
+            .address(addressData.toAddress())
+            .type(capsuleType)
+            .member(member)
+            .dueDate(dueDate)
+            .capsuleSkin(capsuleSkin)
+            .group(group)
+            .build();
+    }
+}

--- a/backend/core/src/main/java/site/timecapsulearchive/core/domain/capsule/group_capsule/data/reqeust/GroupCapsuleCreateRequest.java
+++ b/backend/core/src/main/java/site/timecapsulearchive/core/domain/capsule/group_capsule/data/reqeust/GroupCapsuleCreateRequest.java
@@ -1,33 +1,66 @@
 package site.timecapsulearchive.core.domain.capsule.group_capsule.data.reqeust;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import java.time.ZonedDateTime;
 import java.util.List;
-import org.springframework.web.multipart.MultipartFile;
+import org.hibernate.validator.constraints.Range;
+import site.timecapsulearchive.core.domain.capsule.group_capsule.data.dto.GroupCapsuleCreateRequestDto;
+import site.timecapsulearchive.core.global.common.valid.annotation.Image;
+import site.timecapsulearchive.core.global.common.valid.annotation.Video;
+import site.timecapsulearchive.core.infra.map.data.dto.AddressData;
 
 @Schema(description = "그룹 캡슐 생성 포맷")
 public record GroupCapsuleCreateRequest(
 
-    @Schema(description = "미디어들(이미지, 비디오)")
-    List<MultipartFile> media,
+    @Schema(description = "업로드한 이미지 경로 ex) capsule/1/xxxx.jpg")
+    List<@Image String> imageNames,
+
+    @Schema(description = "업로드한 비디오 경로 ex) capsule/1/xxxx.mp4")
+    List<@Video String> videoNames,
 
     @Schema(description = "캡슐 스킨 아이디")
+    @NotNull(message = "캡슐 스킨 아이디는 필수입니다.")
     Long capsuleSkinId,
 
     @Schema(description = "제목")
+    @NotBlank(message = "캡슐 제목은 필수 입니다.")
     String title,
 
     @Schema(description = "내용")
+    @NotBlank(message = "캡슐 내용은 필수 입니다.")
     String content,
 
-    @Schema(description = "경도")
-    Float longitude,
+    @Range(min = -180, max = 180)
+    @NotNull(message = "현재 경도는 필수 입니다.")
+    @Schema(description = "현재 경도(wsg84)")
+    Double longitude,
 
-    @Schema(description = "위도")
-    Float latitude,
+    @Range(min = -90, max = 90)
+    @NotNull(message = "현재 경도는 필수 입니다.")
+    @Schema(description = "현재 위도(wsg84)")
+    Double latitude,
 
-    @Schema(description = "생성일")
+    @Schema(description = "캡슐 생성 주소")
+    @NotNull(message = "캡슐 생성 주소는 필수 입니다.")
+    AddressData addressData,
+
+    @Schema(description = "개봉일")
     ZonedDateTime dueDate
 ) {
 
+    public GroupCapsuleCreateRequestDto toGroupCapsuleCreateRequestDto() {
+        return GroupCapsuleCreateRequestDto.builder()
+            .videoNames(videoNames)
+            .imageNames(imageNames)
+            .capsuleSkinId(capsuleSkinId)
+            .title(title)
+            .content(content)
+            .longitude(longitude)
+            .latitude(latitude)
+            .addressData(addressData)
+            .dueDate(dueDate)
+            .build();
+    }
 }

--- a/backend/core/src/main/java/site/timecapsulearchive/core/domain/capsule/group_capsule/data/reqeust/GroupCapsuleCreateRequest.java
+++ b/backend/core/src/main/java/site/timecapsulearchive/core/domain/capsule/group_capsule/data/reqeust/GroupCapsuleCreateRequest.java
@@ -14,10 +14,10 @@ import site.timecapsulearchive.core.infra.map.data.dto.AddressData;
 @Schema(description = "그룹 캡슐 생성 포맷")
 public record GroupCapsuleCreateRequest(
 
-    @Schema(description = "업로드한 이미지 경로 ex) capsule/1/xxxx.jpg")
+    @Schema(description = "업로드한 이미지 경로 ex) xxx.jpg")
     List<@Image String> imageNames,
 
-    @Schema(description = "업로드한 비디오 경로 ex) capsule/1/xxxx.mp4")
+    @Schema(description = "업로드한 비디오 경로 ex) xxx.mp4")
     List<@Video String> videoNames,
 
     @Schema(description = "캡슐 스킨 아이디")

--- a/backend/core/src/main/java/site/timecapsulearchive/core/domain/capsule/group_capsule/service/GroupCapsuleService.java
+++ b/backend/core/src/main/java/site/timecapsulearchive/core/domain/capsule/group_capsule/service/GroupCapsuleService.java
@@ -1,0 +1,37 @@
+package site.timecapsulearchive.core.domain.capsule.group_capsule.service;
+
+import lombok.RequiredArgsConstructor;
+import org.locationtech.jts.geom.Point;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import site.timecapsulearchive.core.domain.capsule.entity.Capsule;
+import site.timecapsulearchive.core.domain.capsule.entity.CapsuleType;
+import site.timecapsulearchive.core.domain.capsule.group_capsule.data.dto.GroupCapsuleCreateRequestDto;
+import site.timecapsulearchive.core.domain.capsule.repository.CapsuleRepository;
+import site.timecapsulearchive.core.domain.capsuleskin.entity.CapsuleSkin;
+import site.timecapsulearchive.core.domain.group.entity.Group;
+import site.timecapsulearchive.core.domain.member.entity.Member;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class GroupCapsuleService {
+
+    private final CapsuleRepository capsuleRepository;
+
+    @Transactional
+    public Capsule saveGroupCapsule(
+        GroupCapsuleCreateRequestDto dto,
+        Member member,
+        Group group,
+        CapsuleSkin capsuleSkin,
+        Point point
+    ) {
+        final Capsule capsule = dto.toGroupCapsule(member, capsuleSkin, group,
+            CapsuleType.GROUP, point);
+
+        capsuleRepository.save(capsule);
+
+        return capsule;
+    }
+}

--- a/backend/core/src/main/java/site/timecapsulearchive/core/domain/capsule/repository/GroupCapsuleOpenRepository.java
+++ b/backend/core/src/main/java/site/timecapsulearchive/core/domain/capsule/repository/GroupCapsuleOpenRepository.java
@@ -1,8 +1,0 @@
-package site.timecapsulearchive.core.domain.capsule.repository;
-
-import org.springframework.data.jpa.repository.JpaRepository;
-import site.timecapsulearchive.core.domain.capsule.entity.GroupCapsuleOpen;
-
-public interface GroupCapsuleOpenRepository extends JpaRepository<GroupCapsuleOpen, Long> {
-
-}

--- a/backend/core/src/main/java/site/timecapsulearchive/core/domain/capsule/service/ImageService.java
+++ b/backend/core/src/main/java/site/timecapsulearchive/core/domain/capsule/service/ImageService.java
@@ -1,0 +1,27 @@
+package site.timecapsulearchive.core.domain.capsule.service;
+
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import site.timecapsulearchive.core.domain.capsule.entity.Capsule;
+import site.timecapsulearchive.core.domain.capsule.entity.Image;
+import site.timecapsulearchive.core.domain.capsule.repository.ImageQueryRepository;
+import site.timecapsulearchive.core.domain.member.entity.Member;
+import site.timecapsulearchive.core.infra.s3.data.dto.S3Directory;
+
+@Service
+@RequiredArgsConstructor
+public class ImageService {
+
+    private final ImageQueryRepository imageQueryRepository;
+
+    @Transactional
+    public void bulkSave(List<String> fileNames, Capsule capsule, Member member) {
+        List<String> fullFileNames = fileNames.stream()
+            .map(fileName -> S3Directory.CAPSULE.generateFullPath(member.getId(), fileName))
+            .toList();
+
+        imageQueryRepository.bulkSave(Image.createOf(fullFileNames, capsule, member));
+    }
+}

--- a/backend/core/src/main/java/site/timecapsulearchive/core/domain/capsule/service/VideoService.java
+++ b/backend/core/src/main/java/site/timecapsulearchive/core/domain/capsule/service/VideoService.java
@@ -1,0 +1,27 @@
+package site.timecapsulearchive.core.domain.capsule.service;
+
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import site.timecapsulearchive.core.domain.capsule.entity.Capsule;
+import site.timecapsulearchive.core.domain.capsule.entity.Video;
+import site.timecapsulearchive.core.domain.capsule.repository.VideoQueryRepository;
+import site.timecapsulearchive.core.domain.member.entity.Member;
+import site.timecapsulearchive.core.infra.s3.data.dto.S3Directory;
+
+@Service
+@RequiredArgsConstructor
+public class VideoService {
+
+    private final VideoQueryRepository videoQueryRepository;
+
+    @Transactional
+    public void bulkSave(List<String> fileNames, Capsule capsule, Member member) {
+        List<String> fullFileNames = fileNames.stream()
+            .map(fileName -> S3Directory.CAPSULE.generateFullPath(member.getId(), fileName))
+            .toList();
+
+        videoQueryRepository.bulkSave(Video.createOf(fullFileNames, capsule, member));
+    }
+}

--- a/backend/core/src/main/java/site/timecapsulearchive/core/domain/capsuleskin/service/CapsuleSkinService.java
+++ b/backend/core/src/main/java/site/timecapsulearchive/core/domain/capsuleskin/service/CapsuleSkinService.java
@@ -15,6 +15,7 @@ import site.timecapsulearchive.core.domain.capsuleskin.data.mapper.CapsuleSkinMa
 import site.timecapsulearchive.core.domain.capsuleskin.data.response.CapsuleSkinStatusResponse;
 import site.timecapsulearchive.core.domain.capsuleskin.data.response.CapsuleSkinsSliceResponse;
 import site.timecapsulearchive.core.domain.capsuleskin.entity.CapsuleSkin;
+import site.timecapsulearchive.core.domain.capsuleskin.exception.CapsuleSkinNotFoundException;
 import site.timecapsulearchive.core.domain.capsuleskin.repository.CapsuleSkinMessageManager;
 import site.timecapsulearchive.core.domain.capsuleskin.repository.CapsuleSkinQueryRepository;
 import site.timecapsulearchive.core.domain.capsuleskin.repository.CapsuleSkinRepository;
@@ -95,5 +96,10 @@ public class CapsuleSkinService {
 
     private boolean isNotExistMotionNameAndRetarget(CapsuleSkinCreateDto dto) {
         return dto.motionName() == null && dto.retarget() == null;
+    }
+
+    public CapsuleSkin findCapsuleSkinById(Long capsuleSkinId) {
+        return capsuleSkinRepository.findCapsuleSkinById(capsuleSkinId)
+            .orElseThrow(CapsuleSkinNotFoundException::new);
     }
 }

--- a/backend/core/src/main/java/site/timecapsulearchive/core/domain/group/exception/GroupNotFoundException.java
+++ b/backend/core/src/main/java/site/timecapsulearchive/core/domain/group/exception/GroupNotFoundException.java
@@ -1,0 +1,11 @@
+package site.timecapsulearchive.core.domain.group.exception;
+
+import site.timecapsulearchive.core.global.error.ErrorCode;
+import site.timecapsulearchive.core.global.error.exception.BusinessException;
+
+public class GroupNotFoundException extends BusinessException {
+
+    public GroupNotFoundException() {
+        super(ErrorCode.GROUP_NOT_FOUND_ERROR);
+    }
+}

--- a/backend/core/src/main/java/site/timecapsulearchive/core/domain/group/repository/GroupRepository.java
+++ b/backend/core/src/main/java/site/timecapsulearchive/core/domain/group/repository/GroupRepository.java
@@ -1,8 +1,10 @@
 package site.timecapsulearchive.core.domain.group.repository;
 
-import org.springframework.data.jpa.repository.JpaRepository;
+import java.util.Optional;
+import org.springframework.data.repository.Repository;
 import site.timecapsulearchive.core.domain.group.entity.Group;
 
-public interface GroupRepository extends JpaRepository<Group, Long> {
+public interface GroupRepository extends Repository<Group, Long> {
 
+    Optional<Group> findGroupById(Long groupId);
 }

--- a/backend/core/src/main/java/site/timecapsulearchive/core/domain/group/service/GroupService.java
+++ b/backend/core/src/main/java/site/timecapsulearchive/core/domain/group/service/GroupService.java
@@ -1,0 +1,19 @@
+package site.timecapsulearchive.core.domain.group.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import site.timecapsulearchive.core.domain.group.entity.Group;
+import site.timecapsulearchive.core.domain.group.exception.GroupNotFoundException;
+import site.timecapsulearchive.core.domain.group.repository.GroupRepository;
+
+@Service
+@RequiredArgsConstructor
+public class GroupService {
+
+    private final GroupRepository groupRepository;
+
+    public Group findGroupById(Long groupId) {
+        return groupRepository.findGroupById(groupId)
+            .orElseThrow(GroupNotFoundException::new);
+    }
+}

--- a/backend/core/src/main/java/site/timecapsulearchive/core/domain/member/service/MemberService.java
+++ b/backend/core/src/main/java/site/timecapsulearchive/core/domain/member/service/MemberService.java
@@ -215,4 +215,9 @@ public class MemberService {
 
         return new MemberNotificationStatusResponse(isAlarm);
     }
+
+    public Member findMemberById(Long memberId) {
+        return memberRepository.findMemberById(memberId)
+            .orElseThrow(MemberNotFoundException::new);
+    }
 }

--- a/backend/core/src/main/java/site/timecapsulearchive/core/global/error/ErrorCode.java
+++ b/backend/core/src/main/java/site/timecapsulearchive/core/global/error/ErrorCode.java
@@ -55,7 +55,10 @@ public enum ErrorCode {
 
     //friend
     FRIEND_NOT_FOUND_ERROR(404, "FRIEND-001", "친구를 찾지 못하였습니다"),
-    FRIEND_DUPLICATE_ID_ERROR(404, "FRIEND-001", "친구 아이디가 중복되었습니다.");
+    FRIEND_DUPLICATE_ID_ERROR(404, "FRIEND-001", "친구 아이디가 중복되었습니다."),
+
+    //group
+    GROUP_NOT_FOUND_ERROR(404, "GROUP-001", "그룹을 찾을 수 없습니다");
 
     private final int status;
     private final String code;

--- a/backend/core/src/main/java/site/timecapsulearchive/core/infra/map/data/dto/AddressData.java
+++ b/backend/core/src/main/java/site/timecapsulearchive/core/infra/map/data/dto/AddressData.java
@@ -1,6 +1,7 @@
 package site.timecapsulearchive.core.infra.map.data.dto;
 
 import lombok.Builder;
+import site.timecapsulearchive.core.domain.capsule.entity.Address;
 
 @Builder
 public record AddressData(
@@ -14,5 +15,19 @@ public record AddressData(
     String buildingName,
     String zipCode
 ) {
+
+    public Address toAddress() {
+        return Address.builder()
+            .fullRoadAddressName(fullRoadAddressName)
+            .province(province)
+            .city(city)
+            .subDistinct(subDistinct)
+            .roadName(roadName)
+            .mainBuildingNumber(mainBuildingNumber)
+            .subBuildingNumber(subBuildingNumber)
+            .buildingName(buildingName)
+            .zipCode(zipCode)
+            .build();
+    }
 
 }

--- a/backend/core/src/main/java/site/timecapsulearchive/core/infra/s3/data/dto/S3Directory.java
+++ b/backend/core/src/main/java/site/timecapsulearchive/core/infra/s3/data/dto/S3Directory.java
@@ -1,0 +1,15 @@
+package site.timecapsulearchive.core.infra.s3.data.dto;
+
+public enum S3Directory {
+    CAPSULE("capsuleContents");
+
+    private final String value;
+
+    S3Directory(String value) {
+        this.value = value;
+    }
+
+    public String generateFullPath(final Long memberId, final String fileName) {
+        return value + "/" + memberId + "/" + fileName;
+    }
+}


### PR DESCRIPTION
## 작업 내용 (Content)
- 그룹 캡슐 생성 추가

## 링크 (Links)
- [JIRA 티켓](https://archivetimecapsule.atlassian.net/jira/software/projects/ARCH/boards/1/timeline?selectedIssue=ARCH-159)
- #329 

## 기타 사항 (Etc)
- 서비스 클래스의 의존성을 분리하기 위해 퍼사드 패턴 도입해봄
- 매퍼를 없애고 dto -> entity, request -> dto로 직접 변환하는 방식을 택해봄

## Merge 전 필요 작업 (Checklist before merge)
- 퍼사드 패턴에 대한 의견 공유

## 희망 리뷰 완료 일 (Expected due date)
202X. X. X. Wed
