### PR TITLE
fix : 친구 검색에서 친구, 친구 요청 상태 타입 이상

### DIFF
--- a/backend/core/src/main/java/site/timecapsulearchive/core/domain/friend/data/dto/SearchFriendSummaryDto.java
+++ b/backend/core/src/main/java/site/timecapsulearchive/core/domain/friend/data/dto/SearchFriendSummaryDto.java
@@ -1,5 +1,8 @@
 package site.timecapsulearchive.core.domain.friend.data.dto;
 
+import lombok.Builder;
+
+@Builder
 public record SearchFriendSummaryDto(
     Long id,
     String profileUrl,

--- a/backend/core/src/main/java/site/timecapsulearchive/core/domain/friend/data/dto/SearchTagFriendSummaryDto.java
+++ b/backend/core/src/main/java/site/timecapsulearchive/core/domain/friend/data/dto/SearchTagFriendSummaryDto.java
@@ -1,7 +1,9 @@
 package site.timecapsulearchive.core.domain.friend.data.dto;
 
+import lombok.Builder;
 import site.timecapsulearchive.core.domain.friend.data.response.SearchTagFriendSummaryResponse;
 
+@Builder
 public record SearchTagFriendSummaryDto(
     Long id,
     String profileUrl,

--- a/backend/core/src/main/java/site/timecapsulearchive/core/domain/friend/repository/MemberFriendQueryRepository.java
+++ b/backend/core/src/main/java/site/timecapsulearchive/core/domain/friend/repository/MemberFriendQueryRepository.java
@@ -4,6 +4,7 @@ import static site.timecapsulearchive.core.domain.friend.entity.QFriendInvite.fr
 import static site.timecapsulearchive.core.domain.friend.entity.QMemberFriend.memberFriend;
 import static site.timecapsulearchive.core.domain.member.entity.QMember.member;
 
+import com.querydsl.core.Tuple;
 import com.querydsl.core.types.Projections;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.time.ZonedDateTime;
@@ -96,48 +97,62 @@ public class MemberFriendQueryRepository {
         final List<byte[]> hashes
     ) {
         return jpaQueryFactory
-            .select(
-                Projections.constructor(
-                    SearchFriendSummaryDto.class,
-                    member.id,
-                    member.profileUrl,
-                    member.nickname,
-                    member.phone,
-                    memberFriend.id.isNotNull(),
-                    friendInvite.id.isNotNull()
-                )
-            )
+            .select(member.id, member.profileUrl, member.nickname, member.phone)
             .from(member)
-            .leftJoin(memberFriend)
-            .on(memberFriend.friend.id.eq(member.id).and(memberFriend.owner.id.eq(memberId)))
-            .leftJoin(friendInvite)
-            .on(friendInvite.friend.id.eq(member.id).and(memberFriend.owner.id.eq(memberId)))
             .where(member.phone_hash.in(hashes))
-            .fetch();
+            .fetch()
+            .stream()
+            .map(tuple -> SearchFriendSummaryDto.builder()
+                .id(tuple.get(0, Long.class))
+                .profileUrl(tuple.get(1, String.class))
+                .nickname(tuple.get(2, String.class))
+                .phone(tuple.get(3, byte[].class))
+                .isFriend(checkFriend(memberId, tuple.get(0, Long.class)))
+                .isFriendRequest(checkFriendRequest(memberId, tuple.get(0, Long.class)))
+                .build())
+            .toList();
     }
+
 
     public Optional<SearchTagFriendSummaryDto> findFriendsByTag(
         final Long memberId,
         final String tag
     ) {
-        return Optional.ofNullable(jpaQueryFactory
-            .select(
-                Projections.constructor(
-                    SearchTagFriendSummaryDto.class,
-                    member.id,
-                    member.profileUrl,
-                    member.nickname,
-                    memberFriend.id.isNotNull(),
-                    friendInvite.id.isNotNull()
-                )
-            )
+        Tuple memberDetail = jpaQueryFactory
+            .select(member.id, member.profileUrl, member.nickname)
             .from(member)
-            .leftJoin(memberFriend)
-            .on(memberFriend.friend.id.eq(member.id).and(memberFriend.owner.id.eq(memberId)))
-            .leftJoin(friendInvite)
-            .on(friendInvite.friend.id.eq(member.id).and(memberFriend.owner.id.eq(memberId)))
             .where(member.tag.eq(tag))
-            .fetchOne()
-        );
+            .fetchOne();
+
+        if (memberDetail == null || memberDetail.size() == 0) {
+            return Optional.empty();
+        }
+
+        Boolean isFriend = checkFriend(memberId, memberDetail.get(0, Long.class));
+        Boolean isFriendRequest = checkFriendRequest(memberId, memberDetail.get(0, Long.class));
+
+        return Optional.of(SearchTagFriendSummaryDto.builder()
+            .id(memberDetail.get(0, Long.class))
+            .profileUrl(memberDetail.get(1, String.class))
+            .nickname(memberDetail.get(2, String.class))
+            .isFriend(isFriend)
+            .isFriendRequest(isFriendRequest)
+            .build());
+    }
+
+    private Boolean checkFriend(Long memberId, Long friendId) {
+        Integer isFriendCount = jpaQueryFactory.selectOne()
+            .from(memberFriend)
+            .where(memberFriend.friend.id.eq(friendId).and(memberFriend.owner.id.eq(memberId)))
+            .fetchFirst();
+        return isFriendCount != null;
+    }
+
+    private Boolean checkFriendRequest(Long memberId, Long friendId) {
+        Integer isFriendRequestCount = jpaQueryFactory.selectOne()
+            .from(friendInvite)
+            .where(friendInvite.friend.id.eq(friendId).and(friendInvite.owner.id.eq(memberId)))
+            .fetchFirst();
+        return isFriendRequestCount != null;
     }
 }


### PR DESCRIPTION
## 작업 내용 (Content)
- 친구 태그 검색 / 친구 전화번호 검색  API 에서 친구, 친구 요청 상태(Boolean)이 제대로 전달되지 않음
- 쿼리 수정함

## 링크 (Links)

- [API 스펙 문서](https://github.com/tukcomCD2024/DroidBlossom/issues/336)
- [exist 쿼리 사용](https://jojoldu.tistory.com/775)


## 기타 사항 (Etc)
- 상당히 비효율적임
- 더 좋은 방법이 있으면 적용해야 함

## Merge 전 필요 작업 (Checklist before merge)

## 희망 리뷰 완료 일 (Expected due date)
