### PR TITLE
fix : 알림 서버 url 수정 및 친구 요청 수정

### DIFF
--- a/backend/core/src/main/java/site/timecapsulearchive/core/domain/friend/service/FriendService.java
+++ b/backend/core/src/main/java/site/timecapsulearchive/core/domain/friend/service/FriendService.java
@@ -95,23 +95,27 @@ public class FriendService {
         if (memberId.equals(friendId)) {
             throw new DuplicateFriendIdException();
         }
-        final FriendInvite friendInvite = friendInviteRepository
-            .findFriendInviteWithMembersByOwnerIdAndFriendId(memberId, friendId)
-            .orElseThrow(FriendNotFoundException::new);
 
-        final MemberFriend ownerRelation = friendInvite.ownerRelation();
-        final MemberFriend friendRelation = friendInvite.friendRelation();
-
+        final String[] ownerNickname = new String[1];
         transactionTemplate.execute(new TransactionCallbackWithoutResult() {
             @Override
             protected void doInTransactionWithoutResult(TransactionStatus status) {
+                final FriendInvite friendInvite = friendInviteRepository
+                    .findFriendInviteWithMembersByOwnerIdAndFriendId(memberId, friendId)
+                    .orElseThrow(FriendNotFoundException::new);
+
+                final MemberFriend ownerRelation = friendInvite.ownerRelation();
+                ownerNickname[0] = ownerRelation.getOwnerNickname();
+
+                final MemberFriend friendRelation = friendInvite.friendRelation();
+
                 friendInviteRepository.delete(friendInvite);
                 memberFriendRepository.save(ownerRelation);
                 memberFriendRepository.save(friendRelation);
             }
         });
 
-        notificationManager.sendFriendAcceptMessage(friendId, ownerRelation.getOwnerNickname());
+        notificationManager.sendFriendAcceptMessage(friendId, ownerNickname[0]);
     }
 
     @Transactional
@@ -166,7 +170,8 @@ public class FriendService {
         final Long memberId,
         final List<ByteArrayWrapper> phoneEncryption
     ) {
-        final List<byte[]> hashes = phoneEncryption.stream().map(ByteArrayWrapper::getData).toList();
+        final List<byte[]> hashes = phoneEncryption.stream().map(ByteArrayWrapper::getData)
+            .toList();
 
         return memberFriendQueryRepository.findFriendsByPhone(memberId, hashes);
     }


### PR DESCRIPTION
## 작업 내용 (Content)
- 알림 서버 url 수정
- 친구 요청 서비스 수정

## 링크 (Links)
- #355

## 기타 사항 (Etc)
- 트랜잭션 범위 밖에선 영속 상태가 되지 않으므로 FriendInvite가 트랜잭션 안에서 제거될 때 다시 한 번 쿼리가 발생해서 총 select 2번이 발생함.
- 해당 조회 쿼리 트랜잭션 안으로 수정

## Merge 전 필요 작업 (Checklist before merge)

## 희망 리뷰 완료 일 (Expected due date)