### PR TITLE
feat : 그룹 삭제 API 추가 #405

### DIFF
--- a/backend/core/src/main/java/site/timecapsulearchive/core/domain/capsule/group_capsule/repository/GroupCapsuleQueryRepository.java
+++ b/backend/core/src/main/java/site/timecapsulearchive/core/domain/capsule/group_capsule/repository/GroupCapsuleQueryRepository.java
@@ -166,4 +166,14 @@ public class GroupCapsuleQueryRepository {
 
         return new SliceImpl<>(groupCapsules, Pageable.ofSize(size), hasNext);
     }
+
+    public Optional<Long> findGroupCapsuleCountByGroupId(Long groupId) {
+        return Optional.ofNullable(
+            jpaQueryFactory
+                .select(capsule.count())
+                .from(capsule)
+                .where(capsule.group.id.eq(groupId))
+                .fetchOne()
+        );
+    }
 }

--- a/backend/core/src/main/java/site/timecapsulearchive/core/domain/capsule/group_capsule/repository/GroupCapsuleQueryRepository.java
+++ b/backend/core/src/main/java/site/timecapsulearchive/core/domain/capsule/group_capsule/repository/GroupCapsuleQueryRepository.java
@@ -167,13 +167,13 @@ public class GroupCapsuleQueryRepository {
         return new SliceImpl<>(groupCapsules, Pageable.ofSize(size), hasNext);
     }
 
-    public Optional<Long> findGroupCapsuleCountByGroupId(Long groupId) {
-        return Optional.ofNullable(
-            jpaQueryFactory
-                .select(capsule.count())
-                .from(capsule)
-                .where(capsule.group.id.eq(groupId))
-                .fetchOne()
-        );
+    public boolean findGroupCapsuleExistByGroupId(Long groupId) {
+        Integer count = jpaQueryFactory
+            .selectOne()
+            .from(capsule)
+            .where(capsule.group.id.eq(groupId))
+            .fetchFirst();
+
+        return count != null;
     }
 }

--- a/backend/core/src/main/java/site/timecapsulearchive/core/domain/group/api/GroupApi.java
+++ b/backend/core/src/main/java/site/timecapsulearchive/core/domain/group/api/GroupApi.java
@@ -3,6 +3,7 @@ package site.timecapsulearchive.core.domain.group.api;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
@@ -19,6 +20,7 @@ import site.timecapsulearchive.core.domain.group.data.reqeust.GroupUpdateRequest
 import site.timecapsulearchive.core.domain.group.data.response.GroupDetailResponse;
 import site.timecapsulearchive.core.domain.group.data.response.GroupsSliceResponse;
 import site.timecapsulearchive.core.global.common.response.ApiSpec;
+import site.timecapsulearchive.core.global.error.ErrorResponse;
 
 public interface GroupApi {
 
@@ -66,13 +68,9 @@ public interface GroupApi {
             그룹 삭제를 요청한 사용자가 해당 그룹의 그룹장인 경우 그룹을 삭제한다.<br>
             <b><u>주의</u></b>
             <ul>
-                <li>
-                그룹에 포함된 멤버가 아무도 존재하지 않아야 그룹을 삭제할 수 있다. 만약
-                그룹 멤버가 한 명이라도 존재하면 그룹을 삭제할 수 없다.<br> 이를 먼저 삭제 후 그룹을 삭제할 수 있다.
-                </li>
-                <li>
-                그룹에 그룹 캡슐이 남아있는 경우 삭제할 수 없다.
-                </li>
+                <li>그룹에 포함된 멤버가 그룹장을 제외하고 존재하면 그룹을 삭제할 수 없다.</li>
+                <li>그룹장이 아닌 경우 그룹을 삭제할 수 없다.</li>
+                <li>그룹에 그룹 캡슐이 남아있는 경우 삭제할 수 없다.</li>
             </ul>
             """,
         security = {@SecurityRequirement(name = "user_token")},
@@ -80,9 +78,26 @@ public interface GroupApi {
     )
     @ApiResponses(value = {
         @ApiResponse(
-            responseCode = "204",
-            description = "처리완료"
-        )
+            responseCode = "202",
+            description = "처리 시작"
+        ),
+        @ApiResponse(
+            responseCode = "400",
+            description = """
+                다음의 경우 예외가 발생한다.
+                <ul>
+                <li>삭제를 요청한 그룹에 그룹장을 제외한 그룹원이 존재하는 경우</li>
+                <li>삭제를 요청한 그룹에서 요청한 사용자가 그룹장이 아닌 경우</li>
+                <li>삭제를 요청한 그룹에 그룹 캡슐이 존재하는 경우</li>
+                </ul>
+                """,
+            content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+        ),
+        @ApiResponse(
+            responseCode = "404",
+            description = "그룹이 존재하지 않으면 발생한다.",
+            content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+        ),
     })
     ResponseEntity<ApiSpec<String>> deleteGroupById(
         Long memberId,

--- a/backend/core/src/main/java/site/timecapsulearchive/core/domain/group/api/GroupApi.java
+++ b/backend/core/src/main/java/site/timecapsulearchive/core/domain/group/api/GroupApi.java
@@ -62,7 +62,11 @@ public interface GroupApi {
 
     @Operation(
         summary = "그룹 삭제",
-        description = "그룹장인 경우에 특정 그룹을 삭제한다.",
+        description = """
+            그룹 삭제를 요청한 사용자가 해당 그룹의 그룹장인 경우 그룹을 삭제한다.<br>
+            <b><u>주의</u></b> - 그룹에 포함된 멤버가 아무도 존재하지 않아야 그룹을 삭제할 수 있다. 만약
+            그룹 멤버가 한 명이라도 존재하면 그룹을 삭제할 수 없다.<br> 이를 먼저 삭제 후 그룹을 삭제할 수 있다.
+            """,
         security = {@SecurityRequirement(name = "user_token")},
         tags = {"group"}
     )
@@ -72,10 +76,11 @@ public interface GroupApi {
             description = "처리완료"
         )
     })
-    @DeleteMapping(value = "/groups/{group_id}")
     ResponseEntity<Void> deleteGroupById(
-        @Parameter(in = ParameterIn.PATH, description = "수정할 그룹 아이디", required = true, schema = @Schema())
-        @PathVariable("group_id") Long groupId
+        Long memberId,
+
+        @Parameter(in = ParameterIn.PATH, description = "삭제할 그룹 아이디", required = true)
+        Long groupId
     );
 
     @Operation(

--- a/backend/core/src/main/java/site/timecapsulearchive/core/domain/group/api/GroupApi.java
+++ b/backend/core/src/main/java/site/timecapsulearchive/core/domain/group/api/GroupApi.java
@@ -64,8 +64,16 @@ public interface GroupApi {
         summary = "그룹 삭제",
         description = """
             그룹 삭제를 요청한 사용자가 해당 그룹의 그룹장인 경우 그룹을 삭제한다.<br>
-            <b><u>주의</u></b> - 그룹에 포함된 멤버가 아무도 존재하지 않아야 그룹을 삭제할 수 있다. 만약
-            그룹 멤버가 한 명이라도 존재하면 그룹을 삭제할 수 없다.<br> 이를 먼저 삭제 후 그룹을 삭제할 수 있다.
+            <b><u>주의</u></b>
+            <ul>
+                <li>
+                그룹에 포함된 멤버가 아무도 존재하지 않아야 그룹을 삭제할 수 있다. 만약
+                그룹 멤버가 한 명이라도 존재하면 그룹을 삭제할 수 없다.<br> 이를 먼저 삭제 후 그룹을 삭제할 수 있다.
+                </li>
+                <li>
+                그룹에 그룹 캡슐이 남아있는 경우 삭제할 수 없다.
+                </li>
+            </ul>
             """,
         security = {@SecurityRequirement(name = "user_token")},
         tags = {"group"}
@@ -76,7 +84,7 @@ public interface GroupApi {
             description = "처리완료"
         )
     })
-    ResponseEntity<Void> deleteGroupById(
+    ResponseEntity<ApiSpec<String>> deleteGroupById(
         Long memberId,
 
         @Parameter(in = ParameterIn.PATH, description = "삭제할 그룹 아이디", required = true)

--- a/backend/core/src/main/java/site/timecapsulearchive/core/domain/group/api/GroupApiController.java
+++ b/backend/core/src/main/java/site/timecapsulearchive/core/domain/group/api/GroupApiController.java
@@ -61,13 +61,20 @@ public class GroupApiController implements GroupApi {
         );
     }
 
-    @DeleteMapping(value = "/groups/{group_id}")
+    @DeleteMapping(value = "/{group_id}")
     @Override
-    public ResponseEntity<Void> deleteGroupById(
-        @AuthenticationPrincipal Long memberId,
-        @PathVariable("group_id") Long groupId
+    public ResponseEntity<ApiSpec<String>> deleteGroupById(
+        @AuthenticationPrincipal final Long memberId,
+        @PathVariable("group_id") final Long groupId
     ) {
-        return null;
+        groupService.deleteGroup(memberId, groupId);
+
+        return ResponseEntity.accepted()
+            .body(
+                ApiSpec.empty(
+                    SuccessCode.ACCEPTED
+                )
+            );
     }
 
     @Override

--- a/backend/core/src/main/java/site/timecapsulearchive/core/domain/group/api/GroupApiController.java
+++ b/backend/core/src/main/java/site/timecapsulearchive/core/domain/group/api/GroupApiController.java
@@ -6,6 +6,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Slice;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -60,8 +61,12 @@ public class GroupApiController implements GroupApi {
         );
     }
 
+    @DeleteMapping(value = "/groups/{group_id}")
     @Override
-    public ResponseEntity<Void> deleteGroupById(Long groupId) {
+    public ResponseEntity<Void> deleteGroupById(
+        @AuthenticationPrincipal Long memberId,
+        @PathVariable("group_id") Long groupId
+    ) {
         return null;
     }
 

--- a/backend/core/src/main/java/site/timecapsulearchive/core/domain/group/api/GroupApiController.java
+++ b/backend/core/src/main/java/site/timecapsulearchive/core/domain/group/api/GroupApiController.java
@@ -69,12 +69,7 @@ public class GroupApiController implements GroupApi {
     ) {
         groupService.deleteGroup(memberId, groupId);
 
-        return ResponseEntity.accepted()
-            .body(
-                ApiSpec.empty(
-                    SuccessCode.ACCEPTED
-                )
-            );
+        return ResponseEntity.ok(ApiSpec.empty(SuccessCode.SUCCESS));
     }
 
     @Override

--- a/backend/core/src/main/java/site/timecapsulearchive/core/domain/group/entity/Group.java
+++ b/backend/core/src/main/java/site/timecapsulearchive/core/domain/group/entity/Group.java
@@ -38,12 +38,6 @@ public class Group extends BaseEntity {
     @Column(name = "group_profile_url", nullable = false)
     private String groupProfileUrl;
 
-    @OneToMany(mappedBy = "group", cascade = CascadeType.ALL, orphanRemoval = true)
-    private List<Capsule> capsules;
-
-    @OneToMany(mappedBy = "group", cascade = CascadeType.ALL, orphanRemoval = true)
-    private List<MemberGroup> members;
-
     @Builder
     private Group(String groupName, String groupDescription, String groupProfileUrl) {
         if (Objects.isNull(groupName)

--- a/backend/core/src/main/java/site/timecapsulearchive/core/domain/group/exception/GroupDeleteFailException.java
+++ b/backend/core/src/main/java/site/timecapsulearchive/core/domain/group/exception/GroupDeleteFailException.java
@@ -1,0 +1,11 @@
+package site.timecapsulearchive.core.domain.group.exception;
+
+import site.timecapsulearchive.core.global.error.ErrorCode;
+import site.timecapsulearchive.core.global.error.exception.BusinessException;
+
+public class GroupDeleteFailException extends BusinessException {
+
+    public GroupDeleteFailException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/backend/core/src/main/java/site/timecapsulearchive/core/domain/group/repository/GroupRepository.java
+++ b/backend/core/src/main/java/site/timecapsulearchive/core/domain/group/repository/GroupRepository.java
@@ -10,4 +10,5 @@ public interface GroupRepository extends Repository<Group, Long> {
 
     Optional<Group> findGroupById(Long groupId);
 
+    void delete(Group group);
 }

--- a/backend/core/src/main/java/site/timecapsulearchive/core/domain/group/repository/MemberGroupRepository.java
+++ b/backend/core/src/main/java/site/timecapsulearchive/core/domain/group/repository/MemberGroupRepository.java
@@ -1,9 +1,14 @@
 package site.timecapsulearchive.core.domain.group.repository;
 
+import java.util.List;
 import org.springframework.data.repository.Repository;
 import site.timecapsulearchive.core.domain.group.entity.MemberGroup;
 
 public interface MemberGroupRepository extends Repository<MemberGroup, Long> {
 
     void save(MemberGroup memberGroup);
+
+    List<MemberGroup> findMemberGroupsByGroupId(Long groupId);
+
+    void delete(MemberGroup mg);
 }

--- a/backend/core/src/main/java/site/timecapsulearchive/core/domain/group/service/GroupService.java
+++ b/backend/core/src/main/java/site/timecapsulearchive/core/domain/group/service/GroupService.java
@@ -1,19 +1,21 @@
 package site.timecapsulearchive.core.domain.group.service;
 
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import java.time.ZonedDateTime;
-import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.TransactionStatus;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.transaction.support.TransactionCallbackWithoutResult;
 import org.springframework.transaction.support.TransactionTemplate;
+import site.timecapsulearchive.core.domain.capsule.group_capsule.repository.GroupCapsuleQueryRepository;
 import site.timecapsulearchive.core.domain.group.data.dto.GroupCreateDto;
 import site.timecapsulearchive.core.domain.group.data.dto.GroupDetailDto;
 import site.timecapsulearchive.core.domain.group.data.dto.GroupSummaryDto;
 import site.timecapsulearchive.core.domain.group.entity.Group;
 import site.timecapsulearchive.core.domain.group.entity.MemberGroup;
+import site.timecapsulearchive.core.domain.group.exception.GroupDeleteFailException;
 import site.timecapsulearchive.core.domain.group.exception.GroupNotFoundException;
 import site.timecapsulearchive.core.domain.group.repository.GroupQueryRepository;
 import site.timecapsulearchive.core.domain.group.repository.GroupRepository;
@@ -21,6 +23,7 @@ import site.timecapsulearchive.core.domain.group.repository.MemberGroupRepositor
 import site.timecapsulearchive.core.domain.member.entity.Member;
 import site.timecapsulearchive.core.domain.member.exception.MemberNotFoundException;
 import site.timecapsulearchive.core.domain.member.repository.MemberRepository;
+import site.timecapsulearchive.core.global.error.ErrorCode;
 import site.timecapsulearchive.core.infra.queue.manager.SocialNotificationManager;
 
 @Service
@@ -33,6 +36,7 @@ public class GroupService {
     private final TransactionTemplate transactionTemplate;
     private final SocialNotificationManager socialNotificationManager;
     private final GroupQueryRepository groupQueryRepository;
+    private final GroupCapsuleQueryRepository groupCapsuleQueryRepository;
 
     public void createGroup(final Long memberId, final GroupCreateDto dto) {
         final Member member = memberRepository.findMemberById(memberId)
@@ -83,5 +87,42 @@ public class GroupService {
         }
 
         return groupDetailDto;
+    }
+
+    /**
+     * 사용자가 그룹장인 그룹을 삭제한다.
+     * <br><u><b>주의</b></u> - 그룹 삭제 시 아래 조건에 해당하면 예외가 발생한다.
+     * <br>1. 그룹에 멤버가 존재하는 경우
+     * <br>2. 그룹 삭제를 요청한 사용자가 그룹장이 아닌 경우
+     * <br>3. 그룹에 그룹 캡슐이 남아있는 경우
+     * @param memberId 그룹에 속한 그룹장 아이디
+     * @param groupId 그룹 아이디
+     */
+    @Transactional
+    public void deleteGroup(final Long memberId, final Long groupId) {
+        Group group = groupRepository.findGroupById(groupId)
+            .orElseThrow(GroupNotFoundException::new);
+
+        List<MemberGroup> groupMembers = memberGroupRepository.findMemberGroupsByGroupId(groupId);
+        boolean groupMemberExist = groupMembers.size() > 1;
+        if (groupMemberExist) {
+            throw new GroupDeleteFailException(ErrorCode.GROUP_MEMBER_EXIST_ERROR);
+        }
+        groupMembers.forEach(memberGroupRepository::delete);
+
+        boolean isGroupOwner = groupMembers.stream()
+            .anyMatch(mg -> mg.getMember().getId().equals(memberId) && mg.getIsOwner());
+        if (!isGroupOwner) {
+            throw new GroupDeleteFailException(ErrorCode.NO_GROUP_AUTHORITY_ERROR);
+        }
+
+        Long groupCapsuleCount = groupCapsuleQueryRepository.findGroupCapsuleCountByGroupId(groupId)
+            .orElseThrow(GroupNotFoundException::new);
+        boolean groupCapsuleExist = groupCapsuleCount != 0;
+        if (groupCapsuleExist) {
+            throw new GroupDeleteFailException(ErrorCode.GROUP_CAPSULE_EXIST_ERROR);
+        }
+
+        groupRepository.delete(group);
     }
 }

--- a/backend/core/src/main/java/site/timecapsulearchive/core/domain/group/service/GroupService.java
+++ b/backend/core/src/main/java/site/timecapsulearchive/core/domain/group/service/GroupService.java
@@ -116,9 +116,7 @@ public class GroupService {
         }
         groupMembers.forEach(memberGroupRepository::delete);
 
-        final Long groupCapsuleCount = groupCapsuleQueryRepository.findGroupCapsuleCountByGroupId(groupId)
-            .orElseThrow(GroupNotFoundException::new);
-        final boolean groupCapsuleExist = groupCapsuleCount != 0;
+        final boolean groupCapsuleExist = groupCapsuleQueryRepository.findGroupCapsuleExistByGroupId(groupId);
         if (groupCapsuleExist) {
             throw new GroupDeleteFailException(ErrorCode.GROUP_CAPSULE_EXIST_ERROR);
         }

--- a/backend/core/src/main/java/site/timecapsulearchive/core/domain/group/service/GroupService.java
+++ b/backend/core/src/main/java/site/timecapsulearchive/core/domain/group/service/GroupService.java
@@ -104,17 +104,17 @@ public class GroupService {
             .orElseThrow(GroupNotFoundException::new);
 
         List<MemberGroup> groupMembers = memberGroupRepository.findMemberGroupsByGroupId(groupId);
-        boolean groupMemberExist = groupMembers.size() > 1;
-        if (groupMemberExist) {
-            throw new GroupDeleteFailException(ErrorCode.GROUP_MEMBER_EXIST_ERROR);
-        }
-        groupMembers.forEach(memberGroupRepository::delete);
-
         boolean isGroupOwner = groupMembers.stream()
             .anyMatch(mg -> mg.getMember().getId().equals(memberId) && mg.getIsOwner());
         if (!isGroupOwner) {
             throw new GroupDeleteFailException(ErrorCode.NO_GROUP_AUTHORITY_ERROR);
         }
+
+        boolean groupMemberExist = groupMembers.size() > 1;
+        if (groupMemberExist) {
+            throw new GroupDeleteFailException(ErrorCode.GROUP_MEMBER_EXIST_ERROR);
+        }
+        groupMembers.forEach(memberGroupRepository::delete);
 
         Long groupCapsuleCount = groupCapsuleQueryRepository.findGroupCapsuleCountByGroupId(groupId)
             .orElseThrow(GroupNotFoundException::new);

--- a/backend/core/src/main/java/site/timecapsulearchive/core/domain/group/service/GroupService.java
+++ b/backend/core/src/main/java/site/timecapsulearchive/core/domain/group/service/GroupService.java
@@ -100,25 +100,25 @@ public class GroupService {
      */
     @Transactional
     public void deleteGroup(final Long memberId, final Long groupId) {
-        Group group = groupRepository.findGroupById(groupId)
+        final Group group = groupRepository.findGroupById(groupId)
             .orElseThrow(GroupNotFoundException::new);
 
-        List<MemberGroup> groupMembers = memberGroupRepository.findMemberGroupsByGroupId(groupId);
-        boolean isGroupOwner = groupMembers.stream()
+        final List<MemberGroup> groupMembers = memberGroupRepository.findMemberGroupsByGroupId(groupId);
+        final boolean isGroupOwner = groupMembers.stream()
             .anyMatch(mg -> mg.getMember().getId().equals(memberId) && mg.getIsOwner());
         if (!isGroupOwner) {
             throw new GroupDeleteFailException(ErrorCode.NO_GROUP_AUTHORITY_ERROR);
         }
 
-        boolean groupMemberExist = groupMembers.size() > 1;
+        final boolean groupMemberExist = groupMembers.size() > 1;
         if (groupMemberExist) {
             throw new GroupDeleteFailException(ErrorCode.GROUP_MEMBER_EXIST_ERROR);
         }
         groupMembers.forEach(memberGroupRepository::delete);
 
-        Long groupCapsuleCount = groupCapsuleQueryRepository.findGroupCapsuleCountByGroupId(groupId)
+        final Long groupCapsuleCount = groupCapsuleQueryRepository.findGroupCapsuleCountByGroupId(groupId)
             .orElseThrow(GroupNotFoundException::new);
-        boolean groupCapsuleExist = groupCapsuleCount != 0;
+        final boolean groupCapsuleExist = groupCapsuleCount != 0;
         if (groupCapsuleExist) {
             throw new GroupDeleteFailException(ErrorCode.GROUP_CAPSULE_EXIST_ERROR);
         }

--- a/backend/core/src/main/java/site/timecapsulearchive/core/global/error/ErrorCode.java
+++ b/backend/core/src/main/java/site/timecapsulearchive/core/global/error/ErrorCode.java
@@ -60,6 +60,9 @@ public enum ErrorCode {
     //group
     GROUP_CREATE_ERROR(400, "GROUP-001", "그룹 생성에 실패하였습니다."),
     GROUP_NOT_FOUND_ERROR(404, "GROUP-002", "그룹을 찾을 수 없습니다"),
+    GROUP_MEMBER_EXIST_ERROR(400, "GROUP-003", "다른 그룹 멤버가 존재해 그룹을 삭제할 수 없습니다."),
+    NO_GROUP_AUTHORITY_ERROR(403, "GROUP-004", "그룹에 대한 권한이 존재하지 않습니다."),
+    GROUP_CAPSULE_EXIST_ERROR(400, "GROUP-005", "그룹 캡슐이 존재해 그룹을 삭제할 수 없습니다."),
 
     //friend invite
     FRIEND_INVITE_NOT_FOUND_ERROR(404, "FRIEND-INVITE-001", "친구 요청을 찾지 못하였습니다."),

--- a/backend/core/src/main/java/site/timecapsulearchive/core/infra/s3/config/S3Config.java
+++ b/backend/core/src/main/java/site/timecapsulearchive/core/infra/s3/config/S3Config.java
@@ -6,6 +6,7 @@ import org.springframework.context.annotation.Configuration;
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
 import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.presigner.S3Presigner;
 
 @Configuration
@@ -18,6 +19,14 @@ public class S3Config {
     public S3Presigner s3Presigner() {
         return S3Presigner
             .builder()
+            .credentialsProvider(StaticCredentialsProvider.create(awsBasicCredentials()))
+            .region(Region.of(s3Properties.region()))
+            .build();
+    }
+
+    @Bean
+    public S3Client s3Client() {
+        return S3Client.builder()
             .credentialsProvider(StaticCredentialsProvider.create(awsBasicCredentials()))
             .region(Region.of(s3Properties.region()))
             .build();

--- a/backend/core/src/main/java/site/timecapsulearchive/core/infra/s3/manager/S3ObjectManager.java
+++ b/backend/core/src/main/java/site/timecapsulearchive/core/infra/s3/manager/S3ObjectManager.java
@@ -1,0 +1,42 @@
+package site.timecapsulearchive.core.infra.s3.manager;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import site.timecapsulearchive.core.infra.s3.config.S3Config;
+import software.amazon.awssdk.awscore.exception.AwsServiceException;
+import software.amazon.awssdk.core.exception.SdkClientException;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
+
+@Slf4j
+@Component
+public class S3ObjectManager {
+
+    private final S3Client s3Client;
+    private final String bucketName;
+
+    public S3ObjectManager(S3Client s3Client, S3Config s3config) {
+        this.s3Client = s3Client;
+        this.bucketName = s3config.getBucketName();
+    }
+
+    /**
+     * s3 상의 경로를 입력한다. (버킷명 제외)
+     * <br>ex) capsule/1/test.jpg
+     * @param path s3 상에서 경로
+     */
+    public void deleteObject(String path) {
+        try {
+            s3Client.deleteObject(
+                DeleteObjectRequest.builder()
+                    .bucket(bucketName)
+                    .key(path)
+                    .build()
+            );
+        } catch (AwsServiceException e) {
+            log.error("Aws S3에서 삭제 요청 처리 실패 - {}", path, e);
+        } catch (SdkClientException e) {
+            log.error("Aws S3 삭제 요청 클라이언트 처리 실패 - {}", path, e);
+        }
+    }
+}

--- a/backend/core/src/test/java/site/timecapsulearchive/core/common/fixture/domain/MemberFixture.java
+++ b/backend/core/src/test/java/site/timecapsulearchive/core/common/fixture/domain/MemberFixture.java
@@ -100,4 +100,19 @@ public class MemberFixture {
 
         return result;
     }
+
+    /**
+     * 테스트 픽스처 - 리스트의 {@code Member}의 {@code id}가 주어진 {@code memberId}로 설정된 멤버 엔티티 리스트를 생성한다.
+     * @param startDataPrefix 시작 id
+     * @param count 크기
+     * @return 리스트의 각 {@code Member}의 {@code id}가 {@code memberId}로 설정된 {@code List<Member>} 테스트 픽스처
+     */
+    public static List<Member> membersWithMemberId(int startDataPrefix, int count) {
+        List<Member> result = new ArrayList<>();
+        for (int index = startDataPrefix; index < startDataPrefix + count; index++) {
+            result.add(memberWithMemberId(index));
+        }
+
+        return result;
+    }
 }

--- a/backend/core/src/test/java/site/timecapsulearchive/core/common/fixture/domain/MemberFixture.java
+++ b/backend/core/src/test/java/site/timecapsulearchive/core/common/fixture/domain/MemberFixture.java
@@ -1,5 +1,6 @@
 package site.timecapsulearchive.core.common.fixture.domain;
 
+import java.lang.reflect.Field;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
@@ -13,6 +14,28 @@ import site.timecapsulearchive.core.global.security.encryption.HashEncryptionMan
 public class MemberFixture {
 
     private static final HashEncryptionManager hashEncryptionManager = UnitTestDependency.hashEncryptionManager();
+
+    /**
+     * 테스트 픽스처 - {@code Member}의 {@code id}가 주어진 {@code memberId}로 설정된 멤버 엔티티를 생성한다.
+     * @param memberId 설정할 멤버 아이디
+     * @return {@code Member}의 {@code id}가 {@code memberId}로 설정된 {@code Member} 테스트 픽스처
+     */
+    public static Member memberWithMemberId(long memberId) {
+        try {
+            Member member = member((int) memberId);
+            setFieldValue(member, "id", memberId);
+            return member;
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private static void setFieldValue(Object instance, String fieldName, Object value)
+        throws NoSuchFieldException, IllegalAccessException {
+        Field field = instance.getClass().getDeclaredField(fieldName);
+        field.setAccessible(true);
+        field.set(instance, value);
+    }
 
     /**
      * 테스트 픽스처 - 멤버 마다 상이한 값을 위한 dataPrefix를 주면 멤버를 생성한다.

--- a/backend/core/src/test/java/site/timecapsulearchive/core/common/fixture/domain/MemberGroupFixture.java
+++ b/backend/core/src/test/java/site/timecapsulearchive/core/common/fixture/domain/MemberGroupFixture.java
@@ -16,7 +16,7 @@ public class MemberGroupFixture {
      * @param group 대상 그룹
      * @return 그룹 멤버 테스트 픽스처
      */
-    public static MemberGroup memberGroup(Member member, Group group) {
+    public static MemberGroup groupOwner(Member member, Group group) {
         return MemberGroup.createGroupOwner(member, group);
     }
 

--- a/backend/core/src/test/java/site/timecapsulearchive/core/common/spy/FakeTransactionTemplate.java
+++ b/backend/core/src/test/java/site/timecapsulearchive/core/common/spy/FakeTransactionTemplate.java
@@ -1,0 +1,22 @@
+package site.timecapsulearchive.core.common.spy;
+
+import static org.mockito.Mockito.spy;
+
+import java.util.function.Consumer;
+import org.springframework.transaction.TransactionException;
+import org.springframework.transaction.TransactionStatus;
+import org.springframework.transaction.support.SimpleTransactionStatus;
+import org.springframework.transaction.support.TransactionTemplate;
+
+public class FakeTransactionTemplate extends TransactionTemplate {
+
+    public static FakeTransactionTemplate spied() {
+        return spy(new FakeTransactionTemplate());
+    }
+
+    @Override
+    public void executeWithoutResult(Consumer<TransactionStatus> action)
+        throws TransactionException {
+        action.accept(new SimpleTransactionStatus());
+    }
+}

--- a/backend/core/src/test/java/site/timecapsulearchive/core/domain/capsule/group_capsule/repository/GroupCapsuleOpenQueryRepositoryTest.java
+++ b/backend/core/src/test/java/site/timecapsulearchive/core/domain/capsule/group_capsule/repository/GroupCapsuleOpenQueryRepositoryTest.java
@@ -1,4 +1,4 @@
-package site.timecapsulearchive.core.domain.capsule.repository;
+package site.timecapsulearchive.core.domain.capsule.group_capsule.repository;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -22,7 +22,6 @@ import site.timecapsulearchive.core.common.fixture.domain.MemberFixture;
 import site.timecapsulearchive.core.domain.capsule.entity.Capsule;
 import site.timecapsulearchive.core.domain.capsule.entity.CapsuleType;
 import site.timecapsulearchive.core.domain.capsule.entity.GroupCapsuleOpen;
-import site.timecapsulearchive.core.domain.capsule.group_capsule.repository.GroupCapsuleOpenQueryRepository;
 import site.timecapsulearchive.core.domain.capsuleskin.entity.CapsuleSkin;
 import site.timecapsulearchive.core.domain.member.entity.Member;
 

--- a/backend/core/src/test/java/site/timecapsulearchive/core/domain/group/service/GroupServiceTest.java
+++ b/backend/core/src/test/java/site/timecapsulearchive/core/domain/group/service/GroupServiceTest.java
@@ -2,9 +2,12 @@ package site.timecapsulearchive.core.domain.group.service;
 
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -166,10 +169,6 @@ class GroupServiceTest {
         );
     }
 
-    private Optional<Long> notZeroGroupCapsuleCount() {
-        return Optional.of(999L);
-    }
-
     @Test
     void 그룹을_삭제할_조건을_만족한_그룹_아이디로_삭제를_시도하면_그룹이_삭제된다() {
         //given
@@ -184,5 +183,6 @@ class GroupServiceTest {
         //when
         //then
         assertThatCode(() -> groupService.deleteGroup(groupOwnerId, groupId)).doesNotThrowAnyException();
+        verify(groupRepository, times(1)).delete(any(Group.class));
     }
 }

--- a/backend/core/src/test/java/site/timecapsulearchive/core/domain/group/service/GroupServiceTest.java
+++ b/backend/core/src/test/java/site/timecapsulearchive/core/domain/group/service/GroupServiceTest.java
@@ -148,8 +148,7 @@ class GroupServiceTest {
         given(groupRepository.findGroupById(anyLong())).willReturn(group());
         given(memberGroupRepository.findMemberGroupsByGroupId(groupCapsuleExistGroupId)).willReturn(
             ownerGroupMember());
-        given(groupCapsuleQueryRepository.findGroupCapsuleCountByGroupId(anyLong())).willReturn(
-            notZeroGroupCapsuleCount());
+        given(groupCapsuleQueryRepository.findGroupCapsuleExistByGroupId(anyLong())).willReturn(true);
 
         //when
         //then
@@ -180,8 +179,7 @@ class GroupServiceTest {
         given(groupRepository.findGroupById(anyLong())).willReturn(group());
         given(memberGroupRepository.findMemberGroupsByGroupId(groupId)).willReturn(
             ownerGroupMember());
-        given(groupCapsuleQueryRepository.findGroupCapsuleCountByGroupId(anyLong())).willReturn(
-            Optional.of(0L));
+        given(groupCapsuleQueryRepository.findGroupCapsuleExistByGroupId(anyLong())).willReturn(false);
 
         //when
         //then

--- a/backend/core/src/test/java/site/timecapsulearchive/core/domain/group/service/GroupServiceTest.java
+++ b/backend/core/src/test/java/site/timecapsulearchive/core/domain/group/service/GroupServiceTest.java
@@ -17,6 +17,7 @@ import org.springframework.transaction.support.TransactionTemplate;
 import site.timecapsulearchive.core.common.fixture.domain.GroupFixture;
 import site.timecapsulearchive.core.common.fixture.domain.MemberFixture;
 import site.timecapsulearchive.core.common.fixture.domain.MemberGroupFixture;
+import site.timecapsulearchive.core.common.spy.FakeTransactionTemplate;
 import site.timecapsulearchive.core.domain.capsule.group_capsule.repository.GroupCapsuleQueryRepository;
 import site.timecapsulearchive.core.domain.group.entity.Group;
 import site.timecapsulearchive.core.domain.group.entity.MemberGroup;
@@ -48,7 +49,7 @@ class GroupServiceTest {
     private final GroupRepository groupRepository = mock(GroupRepository.class);
     private final MemberRepository memberRepository = mock(MemberRepository.class);
     private final MemberGroupRepository memberGroupRepository = mock(MemberGroupRepository.class);
-    private final TransactionTemplate transactionTemplate = mock(TransactionTemplate.class);
+    private final TransactionTemplate transactionTemplate = FakeTransactionTemplate.spied();
     private final SocialNotificationManager socialNotificationManager = mock(
         SocialNotificationManager.class);
     private final GroupQueryRepository groupQueryRepository = mock(GroupQueryRepository.class);

--- a/backend/core/src/test/java/site/timecapsulearchive/core/domain/group/service/GroupServiceTest.java
+++ b/backend/core/src/test/java/site/timecapsulearchive/core/domain/group/service/GroupServiceTest.java
@@ -1,0 +1,190 @@
+package site.timecapsulearchive.core.domain.group.service;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.springframework.transaction.support.TransactionTemplate;
+import site.timecapsulearchive.core.common.fixture.domain.GroupFixture;
+import site.timecapsulearchive.core.common.fixture.domain.MemberFixture;
+import site.timecapsulearchive.core.common.fixture.domain.MemberGroupFixture;
+import site.timecapsulearchive.core.domain.capsule.group_capsule.repository.GroupCapsuleQueryRepository;
+import site.timecapsulearchive.core.domain.group.entity.Group;
+import site.timecapsulearchive.core.domain.group.entity.MemberGroup;
+import site.timecapsulearchive.core.domain.group.exception.GroupDeleteFailException;
+import site.timecapsulearchive.core.domain.group.exception.GroupNotFoundException;
+import site.timecapsulearchive.core.domain.group.repository.GroupQueryRepository;
+import site.timecapsulearchive.core.domain.group.repository.GroupRepository;
+import site.timecapsulearchive.core.domain.group.repository.MemberGroupRepository;
+import site.timecapsulearchive.core.domain.member.repository.MemberRepository;
+import site.timecapsulearchive.core.global.error.ErrorCode;
+import site.timecapsulearchive.core.infra.queue.manager.SocialNotificationManager;
+
+/**
+ * 테스트 케이스
+ * <ol>
+ * <li>모든 분기 테스트</li>
+ * <ul>
+ *    <li>그룹이 없는 경우</li>
+ *    <li>그룹원이 있는 경우</li>
+ *    <li>그룹장이 아닌 경우</li>
+ *    <li>그룹 캡슐이 존재하는 경우</li>
+ *    <li>그룹을 삭제할 수 있는 모든 조건(그룹 존재, 그룹에 속한 그룹원 없음, 요청한 사용자가 그룹장, 그룹 캡슐 없음)을 만족한 경우</li>
+ * </ul>
+ * </ol>
+ */
+class GroupServiceTest {
+
+    private final GroupRepository groupRepository = mock(GroupRepository.class);
+    private final MemberRepository memberRepository = mock(MemberRepository.class);
+    private final MemberGroupRepository memberGroupRepository = mock(MemberGroupRepository.class);
+    private final TransactionTemplate transactionTemplate = mock(TransactionTemplate.class);
+    private final SocialNotificationManager socialNotificationManager = mock(
+        SocialNotificationManager.class);
+    private final GroupQueryRepository groupQueryRepository = mock(GroupQueryRepository.class);
+    private final GroupCapsuleQueryRepository groupCapsuleQueryRepository = mock(
+        GroupCapsuleQueryRepository.class);
+
+    private final GroupService groupService = new GroupService(
+        groupRepository,
+        memberRepository,
+        memberGroupRepository,
+        transactionTemplate,
+        socialNotificationManager,
+        groupQueryRepository,
+        groupCapsuleQueryRepository
+    );
+
+    @Test
+    void 존재하지_않는_그룹_아이디로_삭제를_시도하면_예외가_발생한다() {
+        //given
+        Long memberId = 1L;
+        Long notExistGroupId = 1L;
+
+        given(groupRepository.findGroupById(anyLong())).willReturn(Optional.empty());
+
+        //when
+        //then
+        assertThatThrownBy(() -> groupService.deleteGroup(memberId, notExistGroupId))
+            .isExactlyInstanceOf(GroupNotFoundException.class)
+            .hasMessageContaining(ErrorCode.GROUP_NOT_FOUND_ERROR.getMessage());
+    }
+
+    @Test
+    void 그룹원이_존재하는_그룹_아이디로_삭제를_시도하면_예외가_발생한다() {
+        //given
+        Long groupOwnerId = 1L;
+        Long groupMemberExistGroupId = 1L;
+
+        given(groupRepository.findGroupById(anyLong())).willReturn(group());
+        given(memberGroupRepository.findMemberGroupsByGroupId(groupMemberExistGroupId)).willReturn(
+            groupMembers());
+
+        //when
+        //then
+        assertThatThrownBy(() -> groupService.deleteGroup(groupOwnerId, groupMemberExistGroupId))
+            .isExactlyInstanceOf(GroupDeleteFailException.class)
+            .hasMessageContaining(ErrorCode.GROUP_MEMBER_EXIST_ERROR.getMessage());
+    }
+
+    private Optional<Group> group() {
+        return Optional.of(
+            GroupFixture.group()
+        );
+    }
+
+    private List<MemberGroup> groupMembers() {
+        Group group = GroupFixture.group();
+        MemberGroup groupOwner = MemberGroupFixture.groupOwner(MemberFixture.member(1), group);
+
+        List<MemberGroup> memberGroups = MemberGroupFixture.memberGroups(
+            MemberFixture.members(2, 4),
+            group
+        );
+
+        List<MemberGroup> result = new ArrayList<>(memberGroups);
+        result.add(groupOwner);
+        return result;
+    }
+
+    @Test
+    void 그룹장이_아닌_사용자가_그룹_아이디로_삭제를_시도하면_예외가_발생한다() {
+        //given
+        Long groupMemberId = 1L;
+        Long groupId = 1L;
+
+        given(groupRepository.findGroupById(anyLong())).willReturn(group());
+        given(memberGroupRepository.findMemberGroupsByGroupId(groupId)).willReturn(notOwnerGroupMember());
+
+        //when
+        //then
+        assertThatThrownBy(() -> groupService.deleteGroup(groupMemberId, groupId))
+            .isExactlyInstanceOf(GroupDeleteFailException.class)
+            .hasMessageContaining(ErrorCode.NO_GROUP_AUTHORITY_ERROR.getMessage());
+    }
+
+    private List<MemberGroup> notOwnerGroupMember() {
+        return List.of(
+            MemberGroupFixture.memberGroup(
+                MemberFixture.memberWithMemberId(1),
+                GroupFixture.group(),
+                false
+            )
+        );
+    }
+
+    @Test
+    void 그룹_캡슐이_존재하는_그룹_아이디로_삭제를_시도하면_예외가_발생한다() {
+        //given
+        Long groupOwnerId = 1L;
+        Long groupCapsuleExistGroupId = 1L;
+
+        given(groupRepository.findGroupById(anyLong())).willReturn(group());
+        given(memberGroupRepository.findMemberGroupsByGroupId(groupCapsuleExistGroupId)).willReturn(
+            ownerGroupMember());
+        given(groupCapsuleQueryRepository.findGroupCapsuleCountByGroupId(anyLong())).willReturn(
+            notZeroGroupCapsuleCount());
+
+        //when
+        //then
+        assertThatThrownBy(() -> groupService.deleteGroup(groupOwnerId, groupCapsuleExistGroupId))
+            .isExactlyInstanceOf(GroupDeleteFailException.class)
+            .hasMessageContaining(ErrorCode.GROUP_CAPSULE_EXIST_ERROR.getMessage());
+    }
+
+    private List<MemberGroup> ownerGroupMember() {
+        return List.of(
+            MemberGroupFixture.groupOwner(
+                MemberFixture.memberWithMemberId(1),
+                GroupFixture.group()
+            )
+        );
+    }
+
+    private Optional<Long> notZeroGroupCapsuleCount() {
+        return Optional.of(999L);
+    }
+
+    @Test
+    void 그룹을_삭제할_조건을_만족한_그룹_아이디로_삭제를_시도하면_그룹이_삭제된다() {
+        //given
+        Long groupOwnerId = 1L;
+        Long groupId = 1L;
+
+        given(groupRepository.findGroupById(anyLong())).willReturn(group());
+        given(memberGroupRepository.findMemberGroupsByGroupId(groupId)).willReturn(
+            ownerGroupMember());
+        given(groupCapsuleQueryRepository.findGroupCapsuleCountByGroupId(anyLong())).willReturn(
+            Optional.of(0L));
+
+        //when
+        //then
+        assertThatCode(() -> groupService.deleteGroup(groupOwnerId, groupId)).doesNotThrowAnyException();
+    }
+}

--- a/backend/core/src/test/java/site/timecapsulearchive/core/domain/group/service/GroupServiceTest.java
+++ b/backend/core/src/test/java/site/timecapsulearchive/core/domain/group/service/GroupServiceTest.java
@@ -28,6 +28,7 @@ import site.timecapsulearchive.core.domain.group.repository.MemberGroupRepositor
 import site.timecapsulearchive.core.domain.member.repository.MemberRepository;
 import site.timecapsulearchive.core.global.error.ErrorCode;
 import site.timecapsulearchive.core.infra.queue.manager.SocialNotificationManager;
+import site.timecapsulearchive.core.infra.s3.manager.S3ObjectManager;
 
 /**
  * 테스트 케이스
@@ -53,6 +54,7 @@ class GroupServiceTest {
     private final GroupQueryRepository groupQueryRepository = mock(GroupQueryRepository.class);
     private final GroupCapsuleQueryRepository groupCapsuleQueryRepository = mock(
         GroupCapsuleQueryRepository.class);
+    private final S3ObjectManager s3ObjectManager = mock(S3ObjectManager.class);
 
     private final GroupService groupService = new GroupService(
         groupRepository,
@@ -61,7 +63,8 @@ class GroupServiceTest {
         transactionTemplate,
         socialNotificationManager,
         groupQueryRepository,
-        groupCapsuleQueryRepository
+        groupCapsuleQueryRepository,
+        s3ObjectManager
     );
 
     @Test


### PR DESCRIPTION
## 작업 내용 (Content)
- 그룹 삭제 기능 추가

## 링크 (Links)
- [jira - 그룹 삭제](https://archivetimecapsule.atlassian.net/jira/software/projects/ARCH/boards/1?selectedIssue=ARCH-93)
- #405 

## 기타 사항 (Etc)
- 그룹 삭제 시 연쇄 삭제 또는 외래키 제약으로 삭제 실패를 방지하기 위해 <ins>더 강한 제약</ins>이 필요해 제약조건 적용 후 더 자세하게 문서화함. 아래는 그룹 삭제에 필요한 조건들
  **1. 그룹이 존재해야 함.
  2. 그룹 삭제를 요청한 사용자가 그룹장이여야 함.
  3.  그룹에 그룹원이 존재하지 않아야 함.
  4. 그룹에 그룹 캡슐이 존재하지 않아야 함.
  5. 위의 4가지 조건을 만족하면 그룹 삭제**
- 추후 그룹 캡슐 삭제가 필요해 보임

## Merge 전 필요 작업 (Checklist before merge)
- 그룹 관련 작업이 연관되어 있어 그룹 관련 순차적으로 머지 후 최종 머지 필요(ARCH-93-B-feat/group_delete -> 최종)

## 희망 리뷰 완료 일 (Expected due date)
