### PR TITLE
fix : AR용 주변 캡슐 조회 시 친구 캡슐만 조회되는 버그 #409

### DIFF
--- a/backend/core/src/main/java/site/timecapsulearchive/core/domain/capsule/generic_capsule/repository/CapsuleQueryRepository.java
+++ b/backend/core/src/main/java/site/timecapsulearchive/core/domain/capsule/generic_capsule/repository/CapsuleQueryRepository.java
@@ -56,8 +56,7 @@ public class CapsuleQueryRepository {
             .join(capsule.capsuleSkin, capsuleSkin)
             .join(capsule.member, member)
             .where(ST_Contains(mbr, capsule.point).and(capsule.member.id.eq(memberId)
-                    .and(eqCapsuleType(capsuleType)))
-                .and(capsule.type.eq(CapsuleType.PUBLIC)))
+                    .and(eqCapsuleType(capsuleType))))
             .fetch();
     }
 

--- a/backend/core/src/test/java/site/timecapsulearchive/core/domain/capsule/generic_capsule/repository/CapsuleQueryRepositoryTest.java
+++ b/backend/core/src/test/java/site/timecapsulearchive/core/domain/capsule/generic_capsule/repository/CapsuleQueryRepositoryTest.java
@@ -134,6 +134,7 @@ class CapsuleQueryRepositoryTest extends RepositoryTest {
 
         //then
         SoftAssertions.assertSoftly(softly -> {
+            assertThat(capsules).isNotEmpty();
             assertThat(capsules).allMatch(c -> c.capsuleType().equals(capsuleType));
             assertThat(capsules).allMatch(c -> myCapsuleIds.contains(c.id()));
             assertThat(capsules).allMatch(c -> mbr.contains(c.point()));
@@ -153,6 +154,7 @@ class CapsuleQueryRepositoryTest extends RepositoryTest {
 
         //then
         SoftAssertions.assertSoftly(softly -> {
+            assertThat(capsules).isNotEmpty();
             assertThat(capsules).allMatch(c -> c.capsuleType().equals(capsuleType));
             assertThat(capsules).allMatch(c -> myCapsuleIds.contains(c.id()));
             assertThat(capsules).allMatch(c -> mbr.contains(c.point()));
@@ -172,6 +174,7 @@ class CapsuleQueryRepositoryTest extends RepositoryTest {
 
         //then
         SoftAssertions.assertSoftly(softly -> {
+            assertThat(capsules).isNotEmpty();
             assertThat(capsules).allMatch(c -> c.capsuleType().equals(capsuleType));
             assertThat(capsules).allMatch(c -> myCapsuleIds.contains(c.id()));
             assertThat(capsules).allMatch(c -> mbr.contains(c.point()));
@@ -191,6 +194,7 @@ class CapsuleQueryRepositoryTest extends RepositoryTest {
 
         //then
         SoftAssertions.assertSoftly(softly -> {
+            assertThat(capsules).isNotEmpty();
             assertThat(capsules).allMatch(c -> c.capsuleType().equals(capsuleType));
             assertThat(capsules).allMatch(c -> myCapsuleIds.contains(c.id()));
             assertThat(capsules).allMatch(c -> mbr.contains(c.point()));
@@ -210,6 +214,7 @@ class CapsuleQueryRepositoryTest extends RepositoryTest {
 
         //then
         SoftAssertions.assertSoftly(softly -> {
+            assertThat(capsules).isNotEmpty();
             assertThat(capsules).allMatch(
                 c -> c.capsuleType().equals(CapsuleType.PUBLIC) ||
                     c.capsuleType().equals(CapsuleType.SECRET) ||
@@ -233,6 +238,7 @@ class CapsuleQueryRepositoryTest extends RepositoryTest {
 
         //then
         SoftAssertions.assertSoftly(softly -> {
+            assertThat(capsules).isNotEmpty();
             assertThat(capsules).allMatch(
                 c -> c.capsuleType().equals(CapsuleType.PUBLIC) ||
                     c.capsuleType().equals(CapsuleType.SECRET) ||
@@ -255,6 +261,7 @@ class CapsuleQueryRepositoryTest extends RepositoryTest {
 
         //then
         SoftAssertions.assertSoftly(softly -> {
+            assertThat(capsules).isNotEmpty();
             assertThat(capsules).allMatch(c -> friendCapsuleIds.contains(c.id()));
             assertThat(capsules).allMatch(c -> c.capsuleType().equals(CapsuleType.PUBLIC));
             assertThat(capsules).allMatch(c -> mbr.contains(c.point()));
@@ -268,11 +275,12 @@ class CapsuleQueryRepositoryTest extends RepositoryTest {
 
         //when
         List<NearbyARCapsuleSummaryDto> capsules = capsuleQueryRepository.findFriendsARCapsulesByCurrentLocation(
-            friendCapsuleIds, mbr
+            friendIds, mbr
         );
 
         //then
         SoftAssertions.assertSoftly(softly -> {
+            assertThat(capsules).isNotEmpty();
             assertThat(capsules).allMatch(c -> friendCapsuleIds.contains(c.id()));
             assertThat(capsules).allMatch(c -> c.capsuleType().equals(CapsuleType.PUBLIC));
             assertThat(capsules).allMatch(c -> mbr.contains(c.point()));


### PR DESCRIPTION
## 작업 내용 (Content)
- 쿼리 수정
- 기존에 오류를 잡아내지 못한 테스트 수정

## 링크 (Links)
- #409 

## 기타 사항 (Etc)

## Merge 전 필요 작업 (Checklist before merge)

## 희망 리뷰 완료 일 (Expected due date)
