### PR TITLE
feat : 그룹원 추방 기능 추가 #405

### DIFF
--- a/backend/core/src/main/java/site/timecapsulearchive/core/domain/group/api/GroupApi.java
+++ b/backend/core/src/main/java/site/timecapsulearchive/core/domain/group/api/GroupApi.java
@@ -115,6 +115,21 @@ public interface GroupApi {
         @ApiResponse(
             responseCode = "200",
             description = "처리 완료"
+        ),
+        @ApiResponse(
+            responseCode = "400",
+            description = "그룹장과 삭제하려는 대상 그룹원 아이디가 같은 경우에 발생한다.",
+            content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+        ),
+        @ApiResponse(
+            responseCode = "403",
+            description = "그룹장이 아니여서 그룹 수정에 대한 권한이 없는 경우 발생한다.",
+            content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+        ),
+        @ApiResponse(
+            responseCode = "404",
+            description = "삭제하려는 그룹원이 존재하지 않는 경우 발생한다.",
+            content = @Content(schema = @Schema(implementation = ErrorResponse.class))
         )
     })
     ResponseEntity<ApiSpec<String>> deleteGroupMember(

--- a/backend/core/src/main/java/site/timecapsulearchive/core/domain/group/api/GroupApi.java
+++ b/backend/core/src/main/java/site/timecapsulearchive/core/domain/group/api/GroupApi.java
@@ -10,7 +10,6 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import java.time.ZonedDateTime;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -108,23 +107,24 @@ public interface GroupApi {
 
     @Operation(
         summary = "그룹원 삭제",
-        description = "그룹장인 경우 특정 그룹원을 삭제한다.",
+        description = "요청한 사용자가 그룹장인 경우 특정 그룹원을 그룹에서 삭제한다.",
         security = {@SecurityRequirement(name = "user_token")},
         tags = {"group"}
     )
     @ApiResponses(value = {
         @ApiResponse(
-            responseCode = "204",
+            responseCode = "200",
             description = "처리 완료"
         )
     })
-    @DeleteMapping(value = "/groups/{group_id}/members/{member_id}")
-    ResponseEntity<Void> deleteGroupMember(
-        @Parameter(in = ParameterIn.PATH, description = "그룹 아이디", required = true, schema = @Schema())
-        @PathVariable("group_id") Long groupId,
+    ResponseEntity<ApiSpec<String>> deleteGroupMember(
+        Long memberId,
 
-        @Parameter(in = ParameterIn.PATH, description = "삭제할 멤버 아이디", required = true, schema = @Schema())
-        @PathVariable("member_id") Long memberId
+        @Parameter(in = ParameterIn.PATH, description = "그룹 아이디", required = true)
+        Long groupId,
+
+        @Parameter(in = ParameterIn.PATH, description = "삭제할 그룹원 멤버 아이디", required = true)
+        Long groupMemberId
     );
 
     @Operation(

--- a/backend/core/src/main/java/site/timecapsulearchive/core/domain/group/api/GroupApiController.java
+++ b/backend/core/src/main/java/site/timecapsulearchive/core/domain/group/api/GroupApiController.java
@@ -72,9 +72,16 @@ public class GroupApiController implements GroupApi {
         return ResponseEntity.ok(ApiSpec.empty(SuccessCode.SUCCESS));
     }
 
+    @DeleteMapping(value = "/{group_id}/members/{group_member_id}")
     @Override
-    public ResponseEntity<Void> deleteGroupMember(Long groupId, Long memberId) {
-        return null;
+    public ResponseEntity<ApiSpec<String>> deleteGroupMember(
+        @AuthenticationPrincipal final Long memberId,
+        @PathVariable("group_id") final Long groupId,
+        @PathVariable("group_member_id") final Long groupMemberId
+    ) {
+        groupService.deleteGroupMember(memberId, groupId, groupMemberId);
+
+        return ResponseEntity.ok(ApiSpec.empty(SuccessCode.SUCCESS));
     }
 
     @Override

--- a/backend/core/src/main/java/site/timecapsulearchive/core/domain/group/exception/GroupMemberDuplicatedIdException.java
+++ b/backend/core/src/main/java/site/timecapsulearchive/core/domain/group/exception/GroupMemberDuplicatedIdException.java
@@ -1,0 +1,11 @@
+package site.timecapsulearchive.core.domain.group.exception;
+
+import site.timecapsulearchive.core.global.error.ErrorCode;
+import site.timecapsulearchive.core.global.error.exception.BusinessException;
+
+public class GroupMemberDuplicatedIdException extends BusinessException {
+
+    public GroupMemberDuplicatedIdException() {
+        super(ErrorCode.GROUP_MEMBER_DUPLICATED_ID_ERROR);
+    }
+}

--- a/backend/core/src/main/java/site/timecapsulearchive/core/domain/group/exception/NoGroupAuthorityException.java
+++ b/backend/core/src/main/java/site/timecapsulearchive/core/domain/group/exception/NoGroupAuthorityException.java
@@ -1,0 +1,11 @@
+package site.timecapsulearchive.core.domain.group.exception;
+
+import site.timecapsulearchive.core.global.error.ErrorCode;
+import site.timecapsulearchive.core.global.error.exception.BusinessException;
+
+public class NoGroupAuthorityException extends BusinessException {
+
+    public NoGroupAuthorityException() {
+        super(ErrorCode.NO_GROUP_AUTHORITY_ERROR);
+    }
+}

--- a/backend/core/src/main/java/site/timecapsulearchive/core/domain/group/repository/MemberGroupQueryRepository.java
+++ b/backend/core/src/main/java/site/timecapsulearchive/core/domain/group/repository/MemberGroupQueryRepository.java
@@ -1,0 +1,28 @@
+package site.timecapsulearchive.core.domain.group.repository;
+
+import static site.timecapsulearchive.core.domain.group.entity.QMemberGroup.memberGroup;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class MemberGroupQueryRepository {
+
+    private final JPAQueryFactory jpaQueryFactory;
+
+    public Optional<Boolean> findIsOwnerByMemberIdAndGroupId(
+        final Long memberId,
+        final Long groupId
+    ) {
+        return Optional.ofNullable(
+            jpaQueryFactory
+                .select(memberGroup.isOwner)
+                .from(memberGroup)
+                .where(memberGroup.member.id.eq(memberId).and(memberGroup.group.id.eq(groupId)))
+                .fetchOne()
+        );
+    }
+}

--- a/backend/core/src/main/java/site/timecapsulearchive/core/domain/group/service/GroupService.java
+++ b/backend/core/src/main/java/site/timecapsulearchive/core/domain/group/service/GroupService.java
@@ -16,11 +16,14 @@ import site.timecapsulearchive.core.domain.group.data.dto.GroupSummaryDto;
 import site.timecapsulearchive.core.domain.group.entity.Group;
 import site.timecapsulearchive.core.domain.group.entity.MemberGroup;
 import site.timecapsulearchive.core.domain.group.exception.GroupDeleteFailException;
+import site.timecapsulearchive.core.domain.group.exception.GroupMemberDuplicatedIdException;
 import site.timecapsulearchive.core.domain.group.exception.GroupMemberNotfoundException;
 import site.timecapsulearchive.core.domain.group.exception.GroupNotFoundException;
 import site.timecapsulearchive.core.domain.group.exception.GroupQuitException;
+import site.timecapsulearchive.core.domain.group.exception.NoGroupAuthorityException;
 import site.timecapsulearchive.core.domain.group.repository.GroupQueryRepository;
 import site.timecapsulearchive.core.domain.group.repository.GroupRepository;
+import site.timecapsulearchive.core.domain.group.repository.MemberGroupQueryRepository;
 import site.timecapsulearchive.core.domain.group.repository.MemberGroupRepository;
 import site.timecapsulearchive.core.domain.member.entity.Member;
 import site.timecapsulearchive.core.domain.member.exception.MemberNotFoundException;
@@ -39,6 +42,7 @@ public class GroupService {
     private final SocialNotificationManager socialNotificationManager;
     private final GroupQueryRepository groupQueryRepository;
     private final GroupCapsuleQueryRepository groupCapsuleQueryRepository;
+    private final MemberGroupQueryRepository memberGroupQueryRepository;
 
     public void createGroup(final Long memberId, final GroupCreateDto dto) {
         final Member member = memberRepository.findMemberById(memberId)
@@ -120,7 +124,8 @@ public class GroupService {
         }
         groupMembers.forEach(memberGroupRepository::delete);
 
-        final boolean groupCapsuleExist = groupCapsuleQueryRepository.findGroupCapsuleExistByGroupId(groupId);
+        final boolean groupCapsuleExist = groupCapsuleQueryRepository.findGroupCapsuleExistByGroupId(
+            groupId);
         if (groupCapsuleExist) {
             throw new GroupDeleteFailException(ErrorCode.GROUP_CAPSULE_EXIST_ERROR);
         }
@@ -139,12 +144,49 @@ public class GroupService {
     @Transactional
     public void quitGroup(final Long memberId, final Long groupId) {
         final MemberGroup groupMember = memberGroupRepository.findMemberGroupByMemberIdAndGroupId(
-            memberId, groupId)
+                memberId, groupId)
             .orElseThrow(GroupMemberNotfoundException::new);
         if (groupMember.getIsOwner()) {
             throw new GroupQuitException(ErrorCode.GROUP_OWNER_QUIT_ERROR);
         }
 
         memberGroupRepository.delete(groupMember);
+    }
+
+    /**
+     * 그룹의 회원을 그룹에서 삭제한다.
+     * <br><u><b>주의</b></u> - 그룹원 삭제 시 아래 조건에 해당하면 예외가 발생한다.
+     * <br>1. 자신을 삭제하려한 경우
+     * <br>2. 삭제를 요청한 사용자가 그룹장이 아닌 경우
+     * <br>3. 삭제할 대상이 없는 경우
+     *
+     * @param groupOwnerId  그룹장 여부 조회할 대상 사용자
+     * @param groupId       해당 그룹 아이디
+     * @param groupMemberId 삭제할 그룹원 아이디
+     */
+    @Transactional
+    public void deleteGroupMember(
+        final Long groupOwnerId,
+        final Long groupId,
+        final Long groupMemberId
+    ) {
+        if (groupOwnerId.equals(groupMemberId)) {
+            throw new GroupMemberDuplicatedIdException();
+        }
+
+        final Boolean isOwner = memberGroupQueryRepository.findIsOwnerByMemberIdAndGroupId(
+                groupOwnerId,
+                groupId)
+            .orElseThrow(GroupMemberNotfoundException::new);
+        if (!isOwner) {
+            throw new NoGroupAuthorityException();
+        }
+
+        final MemberGroup memberGroup = memberGroupRepository.findMemberGroupByMemberIdAndGroupId(
+                groupId,
+                groupMemberId)
+            .orElseThrow(GroupMemberNotfoundException::new);
+
+        memberGroupRepository.delete(memberGroup);
     }
 }

--- a/backend/core/src/main/java/site/timecapsulearchive/core/domain/group/service/GroupService.java
+++ b/backend/core/src/main/java/site/timecapsulearchive/core/domain/group/service/GroupService.java
@@ -183,8 +183,7 @@ public class GroupService {
         }
 
         final MemberGroup memberGroup = memberGroupRepository.findMemberGroupByMemberIdAndGroupId(
-                groupId,
-                groupMemberId)
+                groupMemberId, groupId)
             .orElseThrow(GroupMemberNotfoundException::new);
 
         memberGroupRepository.delete(memberGroup);

--- a/backend/core/src/main/java/site/timecapsulearchive/core/global/error/ErrorCode.java
+++ b/backend/core/src/main/java/site/timecapsulearchive/core/global/error/ErrorCode.java
@@ -65,6 +65,7 @@ public enum ErrorCode {
     GROUP_CAPSULE_EXIST_ERROR(400, "GROUP-005", "그룹 캡슐이 존재해 그룹을 삭제할 수 없습니다."),
     GROUP_OWNER_QUIT_ERROR(400, "GROUP-006", "그룹장은 그룹을 탈퇴할 수 없습니다."),
     GROUP_MEMBER_NOT_FOUND_ERROR(404, "GROUP-007", "그룹에서 해당 멤버를 찾을 수 없습니다."),
+    GROUP_MEMBER_DUPLICATED_ID_ERROR(400, "GROUP-008", "자신을 추방할 수 없습니다."),
     
     //friend invite
     FRIEND_INVITE_NOT_FOUND_ERROR(404, "FRIEND-INVITE-001", "친구 요청을 찾지 못하였습니다."),

--- a/backend/core/src/test/java/site/timecapsulearchive/core/domain/group/service/GroupServiceTest.java
+++ b/backend/core/src/test/java/site/timecapsulearchive/core/domain/group/service/GroupServiceTest.java
@@ -22,6 +22,7 @@ import site.timecapsulearchive.core.domain.group.exception.GroupNotFoundExceptio
 import site.timecapsulearchive.core.domain.group.exception.GroupQuitException;
 import site.timecapsulearchive.core.domain.group.repository.GroupQueryRepository;
 import site.timecapsulearchive.core.domain.group.repository.GroupRepository;
+import site.timecapsulearchive.core.domain.group.repository.MemberGroupQueryRepository;
 import site.timecapsulearchive.core.domain.group.repository.MemberGroupRepository;
 import site.timecapsulearchive.core.domain.member.repository.MemberRepository;
 import site.timecapsulearchive.core.global.error.ErrorCode;
@@ -57,6 +58,8 @@ class GroupServiceTest {
     private final GroupQueryRepository groupQueryRepository = mock(GroupQueryRepository.class);
     private final GroupCapsuleQueryRepository groupCapsuleQueryRepository = mock(
         GroupCapsuleQueryRepository.class);
+    private final MemberGroupQueryRepository memberGroupQueryRepository = mock(
+        MemberGroupQueryRepository.class);
 
     private final GroupService groupService = new GroupService(
         groupRepository,
@@ -65,7 +68,8 @@ class GroupServiceTest {
         transactionTemplate,
         socialNotificationManager,
         groupQueryRepository,
-        groupCapsuleQueryRepository
+        groupCapsuleQueryRepository,
+        memberGroupQueryRepository
     );
 
     @Test


### PR DESCRIPTION
## 작업 내용 (Content)
- 그룹원 추방 API 추가
- 관련 테스트 추가

## 링크 (Links)
- [jira 그룹 추방](https://archivetimecapsule.atlassian.net/jira/software/projects/ARCH/boards/1?selectedIssue=ARCH-94)
- #405 

## 기타 사항 (Etc)
- 그룹원 추방 시 복잡성을 덜어내기 위해 해당 그룹원이 만든 그룹 캡슐은 삭제하지 않도록 함

## Merge 전 필요 작업 (Checklist before merge)
- 그룹 관련 작업이 연관되어 있어 그룹 관련 순차적으로 머지 후 최종 머지 필요(ARCH-93-B-feat/group_delete -> 최종)

## 희망 리뷰 완료 일 (Expected due date)
