### PR TITLE
feat : 그룹 추방 기능 추가 #405

### DIFF
--- a/backend/core/src/main/java/site/timecapsulearchive/core/domain/group_member/api/command/GroupMemberCommandApi.java
+++ b/backend/core/src/main/java/site/timecapsulearchive/core/domain/group_member/api/command/GroupMemberCommandApi.java
@@ -127,4 +127,41 @@ public interface GroupMemberCommandApi {
         @Parameter(in = ParameterIn.PATH, description = "그룹 초대 대상 아이디", required = true)
         Long groupOwnerId
     );
+
+     @Operation(
+        summary = "그룹원 추방",
+        description = "요청한 사용자가 그룹장인 경우 특정 그룹원을 그룹에서 추방한다.",
+        security = {@SecurityRequirement(name = "user_token")},
+        tags = {"group"}
+    )
+    @ApiResponses(value = {
+        @ApiResponse(
+            responseCode = "200",
+            description = "처리 완료"
+        ),
+        @ApiResponse(
+            responseCode = "400",
+            description = "그룹장과 삭제하려는 대상 그룹원 아이디가 같은 경우에 발생한다.",
+            content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+        ),
+        @ApiResponse(
+            responseCode = "403",
+            description = "그룹장이 아니여서 그룹 수정에 대한 권한이 없는 경우 발생한다.",
+            content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+        ),
+        @ApiResponse(
+            responseCode = "404",
+            description = "삭제하려는 그룹원이 존재하지 않는 경우 발생한다.",
+            content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+        )
+    })
+    ResponseEntity<ApiSpec<String>> kickGroupMember(
+        Long groupOwnerId,
+
+        @Parameter(in = ParameterIn.PATH, description = "그룹 아이디", required = true)
+        Long groupId,
+
+        @Parameter(in = ParameterIn.PATH, description = "추방할 그룹원 멤버 아이디", required = true)
+        Long groupMemberId
+    );
 }

--- a/backend/core/src/main/java/site/timecapsulearchive/core/domain/group_member/api/command/GroupMemberCommandApiController.java
+++ b/backend/core/src/main/java/site/timecapsulearchive/core/domain/group_member/api/command/GroupMemberCommandApiController.java
@@ -76,4 +76,16 @@ public class GroupMemberCommandApiController implements GroupMemberCommandApi {
             )
         );
     }
+
+    @DeleteMapping(value = "/{group_id}/members/{group_member_id}")
+    @Override
+    public ResponseEntity<ApiSpec<String>> kickGroupMember(
+        @AuthenticationPrincipal final Long memberId,
+        @PathVariable("group_id") final Long groupId,
+        @PathVariable("group_member_id") final Long groupMemberId
+    ) {
+        groupMemberCommandService.kickGroupMember(memberId, groupId, groupMemberId);
+
+        return ResponseEntity.ok(ApiSpec.empty(SuccessCode.SUCCESS));
+    }
 }

--- a/backend/core/src/main/java/site/timecapsulearchive/core/domain/group_member/exception/GroupMemberDuplicatedIdException.java
+++ b/backend/core/src/main/java/site/timecapsulearchive/core/domain/group_member/exception/GroupMemberDuplicatedIdException.java
@@ -1,0 +1,11 @@
+package site.timecapsulearchive.core.domain.group_member.exception;
+
+import site.timecapsulearchive.core.global.error.ErrorCode;
+import site.timecapsulearchive.core.global.error.exception.BusinessException;
+
+public class GroupMemberDuplicatedIdException extends BusinessException {
+
+    public GroupMemberDuplicatedIdException() {
+        super(ErrorCode.GROUP_MEMBER_DUPLICATED_ID_ERROR);
+    }
+}

--- a/backend/core/src/main/java/site/timecapsulearchive/core/domain/group_member/repository/memberGroupRepository/MemberGroupQueryRepository.java
+++ b/backend/core/src/main/java/site/timecapsulearchive/core/domain/group_member/repository/memberGroupRepository/MemberGroupQueryRepository.java
@@ -7,4 +7,5 @@ public interface MemberGroupQueryRepository {
 
     Optional<GroupOwnerSummaryDto> findOwnerInMemberGroup(Long groupId, Long memberId);
 
+    Optional<Boolean> findIsOwnerByMemberIdAndGroupId(Long groupOwnerId, Long groupId);
 }

--- a/backend/core/src/main/java/site/timecapsulearchive/core/domain/group_member/repository/memberGroupRepository/MemberGroupQueryRepositoryImpl.java
+++ b/backend/core/src/main/java/site/timecapsulearchive/core/domain/group_member/repository/memberGroupRepository/MemberGroupQueryRepositoryImpl.java
@@ -37,4 +37,18 @@ public class MemberGroupQueryRepositoryImpl implements MemberGroupQueryRepositor
             .fetchFirst()
         );
     }
+
+    @Override
+    public Optional<Boolean> findIsOwnerByMemberIdAndGroupId(
+        final Long memberId,
+        final Long groupId
+    ) {
+        return Optional.ofNullable(
+            jpaQueryFactory
+                .select(memberGroup.isOwner)
+                .from(memberGroup)
+                .where(memberGroup.member.id.eq(memberId).and(memberGroup.group.id.eq(groupId)))
+                .fetchOne()
+        );
+    }
 }

--- a/backend/core/src/main/java/site/timecapsulearchive/core/global/error/ErrorCode.java
+++ b/backend/core/src/main/java/site/timecapsulearchive/core/global/error/ErrorCode.java
@@ -66,6 +66,7 @@ public enum ErrorCode {
     GROUP_CAPSULE_EXIST_ERROR(400, "GROUP-006", "그룹 캡슐이 존재해 그룹을 삭제할 수 없습니다."),
     GROUP_OWNER_QUIT_ERROR(400, "GROUP-007", "그룹장은 그룹을 탈퇴할 수 없습니다."),
     GROUP_MEMBER_NOT_FOUND_ERROR(404, "GROUP-008", "그룹에서 해당 멤버를 찾을 수 없습니다."),
+    GROUP_MEMBER_DUPLICATED_ID_ERROR(400, "GROUP-009", "자신을 추방할 수 없습니다."),
 
     //friend invite
     FRIEND_INVITE_NOT_FOUND_ERROR(404, "FRIEND-INVITE-001", "친구 요청을 찾지 못하였습니다."),


### PR DESCRIPTION
## 작업 내용 (Content)
- 그룹원 추방 API 추가
- 관련 테스트 추가

## 링크 (Links)
- [jira 그룹 추방](https://archivetimecapsule.atlassian.net/jira/software/projects/ARCH/boards/1?selectedIssue=ARCH-94)
- #405 

## 기타 사항 (Etc)
- 그룹원 추방 시 복잡성을 덜어내기 위해 해당 그룹원이 만든 그룹 캡슐은 삭제하지 않도록 함

## Merge 전 필요 작업 (Checklist before merge)
- 그룹 관련 작업이 연관되어 있어 그룹 관련 순차적으로 머지 후 최종 머지 필요(ARCH-93-B-feat/group_delete -> 최종)

## 희망 리뷰 완료 일 (Expected due date)
