### PR TITLE
performance : 그룹 상세조회 쿼리 개선

### DIFF
--- a/backend/core/src/main/java/site/timecapsulearchive/core/domain/group/data/dto/GroupDetailDto.java
+++ b/backend/core/src/main/java/site/timecapsulearchive/core/domain/group/data/dto/GroupDetailDto.java
@@ -8,6 +8,7 @@ public record GroupDetailDto(
     String groupDescription,
     String groupProfileUrl,
     ZonedDateTime createdAt,
+    Boolean isOwner,
     List<GroupMemberDto> members
 ) {
 
@@ -16,9 +17,10 @@ public record GroupDetailDto(
         String groupDescription,
         String groupProfileUrl,
         ZonedDateTime createdAt,
+        Boolean isOwner,
         List<GroupMemberDto> members
     ) {
-        return new GroupDetailDto(groupName, groupDescription, groupProfileUrl, createdAt, members);
+        return new GroupDetailDto(groupName, groupDescription, groupProfileUrl, createdAt, isOwner, members);
     }
 
 }

--- a/backend/core/src/main/java/site/timecapsulearchive/core/domain/group/data/dto/GroupDetailTotalDto.java
+++ b/backend/core/src/main/java/site/timecapsulearchive/core/domain/group/data/dto/GroupDetailTotalDto.java
@@ -19,7 +19,6 @@ public record GroupDetailTotalDto(
     public static GroupDetailTotalDto as(
         final GroupDetailDto groupDetailDto,
         final Long groupCapsuleTotalCount,
-        final Boolean canGroupEdit,
         final List<Long> friendIds
     ) {
         final List<GroupMemberWithRelationDto> membersWithRelation = groupDetailDto.members()
@@ -33,7 +32,7 @@ public record GroupDetailTotalDto(
             groupDetailDto.groupProfileUrl(),
             groupDetailDto.createdAt(),
             groupCapsuleTotalCount,
-            canGroupEdit,
+            groupDetailDto.isOwner(),
             membersWithRelation
         );
     }

--- a/backend/core/src/main/java/site/timecapsulearchive/core/domain/group/repository/GroupQueryRepository.java
+++ b/backend/core/src/main/java/site/timecapsulearchive/core/domain/group/repository/GroupQueryRepository.java
@@ -17,6 +17,4 @@ public interface GroupQueryRepository {
 
     Optional<GroupDetailDto> findGroupDetailByGroupIdAndMemberId(final Long groupId,
         final Long memberId);
-
-    Boolean findGroupEditPermission(final Long groupId, final Long memberId);
 }

--- a/backend/core/src/main/java/site/timecapsulearchive/core/domain/group/service/query/GroupQueryService.java
+++ b/backend/core/src/main/java/site/timecapsulearchive/core/domain/group/service/query/GroupQueryService.java
@@ -43,13 +43,12 @@ public class GroupQueryService {
             groupId, memberId).orElseThrow(GroupNotFoundException::new);
 
         final Long groupCapsuleCount = groupCapsuleQueryRepository.findGroupCapsuleCount(groupId);
-        final Boolean canGroupEdit = groupRepository.findGroupEditPermission(groupId, memberId);
 
         final List<Long> groupMemberIds = groupDetailDto.members().stream()
             .map(GroupMemberDto::memberId)
             .toList();
         final List<Long> friendIds = memberFriendRepository.findFriendIds(groupMemberIds, memberId);
 
-        return GroupDetailTotalDto.as(groupDetailDto, groupCapsuleCount, canGroupEdit, friendIds);
+        return GroupDetailTotalDto.as(groupDetailDto, groupCapsuleCount, friendIds);
     }
 }

--- a/backend/core/src/test/java/site/timecapsulearchive/core/domain/group/repository/GroupQueryRepositoryImplTest.java
+++ b/backend/core/src/test/java/site/timecapsulearchive/core/domain/group/repository/GroupQueryRepositoryImplTest.java
@@ -1,0 +1,129 @@
+package site.timecapsulearchive.core.domain.group.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import java.util.List;
+import java.util.Optional;
+import org.assertj.core.api.SoftAssertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.TestConstructor;
+import org.springframework.test.context.TestConstructor.AutowireMode;
+import org.springframework.transaction.annotation.Transactional;
+import site.timecapsulearchive.core.common.RepositoryTest;
+import site.timecapsulearchive.core.common.fixture.domain.GroupFixture;
+import site.timecapsulearchive.core.common.fixture.domain.MemberFixture;
+import site.timecapsulearchive.core.common.fixture.domain.MemberGroupFixture;
+import site.timecapsulearchive.core.domain.group.data.dto.GroupDetailDto;
+import site.timecapsulearchive.core.domain.group.entity.Group;
+import site.timecapsulearchive.core.domain.member.entity.Member;
+import site.timecapsulearchive.core.domain.member_group.entity.MemberGroup;
+
+@TestConstructor(autowireMode = AutowireMode.ALL)
+class GroupQueryRepositoryImplTest extends RepositoryTest {
+
+    private final GroupQueryRepository groupQueryRepository;
+
+    private Long groupId;
+    private Long ownerId;
+    private Long groupMemberId;
+
+    GroupQueryRepositoryImplTest(JPAQueryFactory jpaQueryFactory) {
+        this.groupQueryRepository = new GroupQueryRepositoryImpl(jpaQueryFactory);
+    }
+
+    @Transactional
+    @BeforeEach
+    void setup(@Autowired EntityManager entityManager) {
+        Group group = GroupFixture.group();
+        entityManager.persist(group);
+        groupId = group.getId();
+
+        Member member = MemberFixture.member(1);
+        entityManager.persist(member);
+        ownerId = member.getId();
+
+        MemberGroup memberGroup = MemberGroupFixture.groupOwner(member, group);
+        entityManager.persist(memberGroup);
+
+        List<Member> members = MemberFixture.members(2, 10);
+        for (Member m : members) {
+            entityManager.persist(m);
+
+            MemberGroup mg = MemberGroupFixture.memberGroup(m, group, Boolean.FALSE);
+            entityManager.persist(mg);
+        }
+        groupMemberId = members.get(0).getId();
+    }
+
+    @Test
+    void 그룹_아이디로_그룹을_상세정보를_조회하면_그룹의_상세정보를_볼_수_있다() {
+        //given
+        //when
+        GroupDetailDto groupDetailDto = groupQueryRepository.findGroupDetailByGroupIdAndMemberId(
+                groupId, ownerId)
+            .orElseThrow();
+
+        //then
+        SoftAssertions.assertSoftly(softly -> {
+            softly.assertThat(groupDetailDto.groupName()).isNotBlank();
+            softly.assertThat(groupDetailDto.groupDescription()).isNotBlank();
+            softly.assertThat(groupDetailDto.groupProfileUrl()).isNotBlank();
+            softly.assertThat(groupDetailDto.groupProfileUrl()).isNotBlank();
+            softly.assertThat(groupDetailDto.createdAt()).isNotNull();
+            softly.assertThat(groupDetailDto.members()).isNotEmpty();
+        });
+    }
+
+    @Test
+    void 그룹_아이디로_그룹을_상세정보를_조회하면_사용자를_제외한_그룹원의_정보를_볼_수_있다() {
+        //given
+        //when
+        GroupDetailDto groupDetailDto = groupQueryRepository.findGroupDetailByGroupIdAndMemberId(
+                groupId, ownerId)
+            .orElseThrow();
+
+        //then
+        assertThat(groupDetailDto.members()).noneMatch(m -> m.memberId().equals(ownerId));
+    }
+
+    @Test
+    void 존재하지_않는_그룹_아이디로_그룹을_상세정보를_조회하면_예외가_발생한다() {
+        //given
+        Long notExistGroupId = 999L;
+
+        //when
+        Optional<GroupDetailDto> groupDetailDto = groupQueryRepository.findGroupDetailByGroupIdAndMemberId(
+            notExistGroupId, ownerId);
+
+        //then
+        assertThat(groupDetailDto).isEmpty();
+    }
+
+    @Test
+    void 그룹장이_그룹을_상세정보를_조회하면_그룹의_수정권한을_가진다() {
+        //given
+        //when
+        GroupDetailDto groupDetailDto = groupQueryRepository.findGroupDetailByGroupIdAndMemberId(
+                groupId, ownerId)
+            .orElseThrow();
+
+        //then
+        assertThat(groupDetailDto.isOwner()).isTrue();
+    }
+
+    @Test
+    void 그룹원이_그룹을_상세정보를_조회하면_그룹의_수정권한이_없다() {
+        //given
+        //when
+        GroupDetailDto groupDetailDto = groupQueryRepository.findGroupDetailByGroupIdAndMemberId(
+                groupId, groupMemberId)
+            .orElseThrow();
+
+        //then
+        assertThat(groupDetailDto.isOwner()).isFalse();
+    }
+}

--- a/backend/core/src/test/java/site/timecapsulearchive/core/domain/group/repository/GroupQueryRepositoryImplTest.java
+++ b/backend/core/src/test/java/site/timecapsulearchive/core/domain/group/repository/GroupQueryRepositoryImplTest.java
@@ -18,6 +18,7 @@ import site.timecapsulearchive.core.common.fixture.domain.GroupFixture;
 import site.timecapsulearchive.core.common.fixture.domain.MemberFixture;
 import site.timecapsulearchive.core.common.fixture.domain.MemberGroupFixture;
 import site.timecapsulearchive.core.domain.group.data.dto.GroupDetailDto;
+import site.timecapsulearchive.core.domain.group.data.dto.GroupMemberDto;
 import site.timecapsulearchive.core.domain.group.entity.Group;
 import site.timecapsulearchive.core.domain.member.entity.Member;
 import site.timecapsulearchive.core.domain.member_group.entity.MemberGroup;
@@ -57,6 +58,69 @@ class GroupQueryRepositoryImplTest extends RepositoryTest {
             entityManager.persist(mg);
         }
         groupMemberId = members.get(0).getId();
+    }
+
+    @Test
+    void 그룹_아이디와_멤버_아이디로_그룹을_조회하면_그룹_상세가_반환된다() {
+        //given
+        //when
+        GroupDetailDto groupDetail = groupQueryRepository.findGroupDetailByGroupIdAndMemberId(
+            groupId, ownerId).orElseThrow();
+
+        //then
+        assertThat(groupDetail).isNotNull();
+    }
+
+    @Test
+    void 그룹_아이디와_멤버_아이디로_그룹을_조회하면_그룹_정보를_볼_수_있다() {
+        //given
+        //when
+        GroupDetailDto groupDetail = groupQueryRepository.findGroupDetailByGroupIdAndMemberId(
+            groupId, ownerId).orElseThrow();
+
+        //then
+        SoftAssertions.assertSoftly(softly -> {
+            assertThat(groupDetail.groupName()).isNotBlank();
+            assertThat(groupDetail.groupDescription()).isNotBlank();
+            assertThat(groupDetail.groupProfileUrl()).isNotBlank();
+            assertThat(groupDetail.createdAt()).isNotNull();
+        });
+    }
+
+    @Test
+    void 그룹_아이디와_멤버_아이디_그룹을_조회하면_그룹원들의_정보를_볼_수_있다() {
+        //given
+        //when
+        GroupDetailDto groupDetail = groupQueryRepository.findGroupDetailByGroupIdAndMemberId(
+            groupId, groupMemberId).orElseThrow();
+
+        //then
+        SoftAssertions.assertSoftly(softly -> {
+            assertThat(groupDetail.members()).isNotEmpty();
+            assertThat(groupDetail.members()).allSatisfy(m -> assertThat(m.memberId()).isNotNull());
+            assertThat(groupDetail.members()).allSatisfy(m -> assertThat(m.tag()).isNotBlank());
+            assertThat(groupDetail.members()).allSatisfy(
+                m -> assertThat(m.nickname()).isNotBlank());
+            assertThat(groupDetail.members()).allSatisfy(
+                m -> assertThat(m.profileUrl()).isNotBlank());
+            assertThat(groupDetail.members()).allSatisfy(m -> assertThat(m.isOwner()).isNotNull());
+        });
+    }
+
+    @Test
+    void 그룹_아이디와_멤버_아이디로_그룹을_조회하면_본인은_포함되어_조회되지_않는다() {
+        //given
+        //when
+        GroupDetailDto groupDetail = groupQueryRepository.findGroupDetailByGroupIdAndMemberId(
+            groupId, groupMemberId).orElseThrow();
+
+        List<GroupMemberDto> groupMemberDtos = groupDetail.members();
+
+        //then
+        SoftAssertions.assertSoftly(softly -> {
+            softly.assertThat(groupMemberDtos)
+                .noneMatch(member -> member.memberId().equals(groupMemberId));
+        });
     }
 
     @Test

--- a/backend/core/src/test/java/site/timecapsulearchive/core/domain/group/repository/GroupQueryRepositoryImplTest.java
+++ b/backend/core/src/test/java/site/timecapsulearchive/core/domain/group/repository/GroupQueryRepositoryImplTest.java
@@ -84,6 +84,7 @@ class GroupQueryRepositoryImplTest extends RepositoryTest {
             assertThat(groupDetail.groupDescription()).isNotBlank();
             assertThat(groupDetail.groupProfileUrl()).isNotBlank();
             assertThat(groupDetail.createdAt()).isNotNull();
+            assertThat(groupDetail.members()).isNotEmpty();
         });
     }
 
@@ -120,25 +121,6 @@ class GroupQueryRepositoryImplTest extends RepositoryTest {
         SoftAssertions.assertSoftly(softly -> {
             softly.assertThat(groupMemberDtos)
                 .noneMatch(member -> member.memberId().equals(groupMemberId));
-        });
-    }
-
-    @Test
-    void 그룹_아이디로_그룹을_상세정보를_조회하면_그룹의_상세정보를_볼_수_있다() {
-        //given
-        //when
-        GroupDetailDto groupDetailDto = groupQueryRepository.findGroupDetailByGroupIdAndMemberId(
-                groupId, ownerId)
-            .orElseThrow();
-
-        //then
-        SoftAssertions.assertSoftly(softly -> {
-            softly.assertThat(groupDetailDto.groupName()).isNotBlank();
-            softly.assertThat(groupDetailDto.groupDescription()).isNotBlank();
-            softly.assertThat(groupDetailDto.groupProfileUrl()).isNotBlank();
-            softly.assertThat(groupDetailDto.groupProfileUrl()).isNotBlank();
-            softly.assertThat(groupDetailDto.createdAt()).isNotNull();
-            softly.assertThat(groupDetailDto.members()).isNotEmpty();
         });
     }
 

--- a/backend/core/src/test/java/site/timecapsulearchive/core/domain/member_group/repository/MemberGroupQueryRepositoryTest.java
+++ b/backend/core/src/test/java/site/timecapsulearchive/core/domain/member_group/repository/MemberGroupQueryRepositoryTest.java
@@ -1,4 +1,4 @@
-package site.timecapsulearchive.core.domain.group.repository;
+package site.timecapsulearchive.core.domain.member_group.repository;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.SoftAssertions.assertSoftly;
@@ -26,6 +26,8 @@ import site.timecapsulearchive.core.domain.group.data.dto.GroupDetailDto;
 import site.timecapsulearchive.core.domain.group.data.dto.GroupMemberDto;
 import site.timecapsulearchive.core.domain.group.data.dto.GroupSummaryDto;
 import site.timecapsulearchive.core.domain.group.entity.Group;
+import site.timecapsulearchive.core.domain.group.repository.GroupQueryRepository;
+import site.timecapsulearchive.core.domain.group.repository.GroupQueryRepositoryImpl;
 import site.timecapsulearchive.core.domain.member.entity.Member;
 import site.timecapsulearchive.core.domain.member_group.entity.MemberGroup;
 

--- a/backend/core/src/test/java/site/timecapsulearchive/core/domain/member_group/repository/MemberGroupQueryRepositoryTest.java
+++ b/backend/core/src/test/java/site/timecapsulearchive/core/domain/member_group/repository/MemberGroupQueryRepositoryTest.java
@@ -40,7 +40,6 @@ class MemberGroupQueryRepositoryTest extends RepositoryTest {
 
     private Long memberId;
     private Long memberIdWithNoGroup;
-    private Long ownerGroupId;
 
     MemberGroupQueryRepositoryTest(JPAQueryFactory jpaQueryFactory) {
         this.groupQueryRepository = new GroupQueryRepositoryImpl(jpaQueryFactory);
@@ -66,9 +65,6 @@ class MemberGroupQueryRepositoryTest extends RepositoryTest {
             entityManager.persist(group);
             groups.add(group);
         }
-
-        //사용자가 그룹장인 그룹아이디
-        ownerGroupId = groups.get(0).getId();
 
         //그룹원들
         List<Member> members = MemberFixture.members(4, 2);
@@ -149,68 +145,5 @@ class MemberGroupQueryRepositoryTest extends RepositoryTest {
 
         //then
         assertThat(groupsSlice.isEmpty()).isTrue();
-    }
-
-    @Test
-    void 그룹_아이디와_멤버_아이디로_그룹을_조회하면_그룹_상세가_반환된다() {
-        //given
-        //when
-        GroupDetailDto groupDetail = groupQueryRepository.findGroupDetailByGroupIdAndMemberId(
-            ownerGroupId, memberId).orElseThrow();
-
-        //then
-        assertThat(groupDetail).isNotNull();
-    }
-
-    @Test
-    void 그룹_아이디와_멤버_아이디로_그룹을_조회하면_그룹_정보를_볼_수_있다() {
-        //given
-        //when
-        GroupDetailDto groupDetail = groupQueryRepository.findGroupDetailByGroupIdAndMemberId(
-            ownerGroupId, memberId).orElseThrow();
-
-        //then
-        SoftAssertions.assertSoftly(softly -> {
-            assertThat(groupDetail.groupName()).isNotBlank();
-            assertThat(groupDetail.groupDescription()).isNotBlank();
-            assertThat(groupDetail.groupProfileUrl()).isNotBlank();
-            assertThat(groupDetail.createdAt()).isNotNull();
-        });
-    }
-
-    @Test
-    void 그룹_아이디와_멤버_아이디_그룹을_조회하면_그룹원들의_정보를_볼_수_있다() {
-        //given
-        //when
-        GroupDetailDto groupDetail = groupQueryRepository.findGroupDetailByGroupIdAndMemberId(
-            ownerGroupId, memberId).orElseThrow();
-
-        //then
-        SoftAssertions.assertSoftly(softly -> {
-            assertThat(groupDetail.members()).isNotEmpty();
-            assertThat(groupDetail.members()).allSatisfy(m -> assertThat(m.memberId()).isNotNull());
-            assertThat(groupDetail.members()).allSatisfy(m -> assertThat(m.tag()).isNotBlank());
-            assertThat(groupDetail.members()).allSatisfy(
-                m -> assertThat(m.nickname()).isNotBlank());
-            assertThat(groupDetail.members()).allSatisfy(
-                m -> assertThat(m.profileUrl()).isNotBlank());
-            assertThat(groupDetail.members()).allSatisfy(m -> assertThat(m.isOwner()).isNotNull());
-        });
-    }
-
-    @Test
-    void 그룹_아이디와_멤버_아이디로_그룹을_조회하면_본인은_포함되어_조회되지_않는다() {
-        //given
-        //when
-        GroupDetailDto groupDetail = groupQueryRepository.findGroupDetailByGroupIdAndMemberId(
-            ownerGroupId, memberId).orElseThrow();
-
-        List<GroupMemberDto> groupMemberDtos = groupDetail.members();
-
-        //then
-        SoftAssertions.assertSoftly(softly -> {
-            softly.assertThat(groupMemberDtos)
-                .noneMatch(member -> member.memberId().equals(memberId));
-        });
     }
 }


### PR DESCRIPTION
## 작업 내용 (Content)
- 그룹 상세조회 쿼리 개선

## 링크 (Links)
- #455

## 기타 사항 (Etc)
- 기존 쿼리에서는 조인 조건에 그룹 아이디와 비교가 있어서 테이블을 풀스캔함, 그룹의 권한 조회를 위한 추가 쿼리가 필요
조인 조건이 아닌 where절로 그룹 아이디 비교하도록 이동, 그룹 상세조회시 가져온 리스트로 그룹권한 추출해 그룹 권한 조회 쿼리 제거

## Merge 전 필요 작업 (Checklist before merge)

## 희망 리뷰 완료 일 (Expected due date)