### PR TITLE
fix : 그룹 캡슐 개봉 로직 수정

### DIFF
--- a/backend/core/src/main/java/site/timecapsulearchive/core/domain/capsule/entity/Capsule.java
+++ b/backend/core/src/main/java/site/timecapsulearchive/core/domain/capsule/entity/Capsule.java
@@ -16,12 +16,14 @@ import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
+import java.util.ArrayList;
 import java.util.List;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.locationtech.jts.geom.Point;
+import site.timecapsulearchive.core.domain.capsule.exception.GroupCapsuleOpenNotFoundException;
 import site.timecapsulearchive.core.domain.capsuleskin.entity.CapsuleSkin;
 import site.timecapsulearchive.core.domain.group.entity.Group;
 import site.timecapsulearchive.core.domain.member.entity.Member;
@@ -61,13 +63,13 @@ public class Capsule extends BaseEntity {
     private Address address;
 
     @OneToMany(mappedBy = "capsule", cascade = CascadeType.ALL, orphanRemoval = true)
-    private List<Image> images;
+    private List<Image> images = new ArrayList<>();
 
     @OneToMany(mappedBy = "capsule", cascade = CascadeType.ALL, orphanRemoval = true)
-    private List<Video> videos;
+    private List<Video> videos = new ArrayList<>();
 
     @OneToMany(mappedBy = "capsule", cascade = CascadeType.ALL, orphanRemoval = true)
-    private List<GroupCapsuleOpen> groupCapsuleOpens;
+    private List<GroupCapsuleOpen> groupCapsuleOpens = new ArrayList<>();
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "group_id")
@@ -123,5 +125,20 @@ public class Capsule extends BaseEntity {
 
     public boolean canOpen() {
         return dueDate == null || dueDate.isBefore(ZonedDateTime.now(ZoneId.of("UTC")));
+    }
+
+    public boolean isAllGroupMemberOpened(Long memberId, Long capsuleId) {
+        if (groupCapsuleOpens.isEmpty()) {
+            throw new GroupCapsuleOpenNotFoundException();
+        }
+
+        return groupCapsuleOpens.stream()
+            .allMatch(groupCapsuleOpen -> {
+                if (groupCapsuleOpen.matched(capsuleId, memberId)) {
+                    groupCapsuleOpen.open();
+                }
+
+                return groupCapsuleOpen.getIsOpened();
+            });
     }
 }

--- a/backend/core/src/main/java/site/timecapsulearchive/core/domain/capsule/entity/Capsule.java
+++ b/backend/core/src/main/java/site/timecapsulearchive/core/domain/capsule/entity/Capsule.java
@@ -111,4 +111,8 @@ public class Capsule extends BaseEntity {
 
         return dueDate.isAfter(ZonedDateTime.now());
     }
+
+    public void open() {
+        this.isOpened = Boolean.TRUE;
+    }
 }

--- a/backend/core/src/main/java/site/timecapsulearchive/core/domain/capsule/entity/Capsule.java
+++ b/backend/core/src/main/java/site/timecapsulearchive/core/domain/capsule/entity/Capsule.java
@@ -115,4 +115,8 @@ public class Capsule extends BaseEntity {
     public void open() {
         this.isOpened = Boolean.TRUE;
     }
+
+    public boolean isTimeCapsule() {
+        return dueDate != null;
+    }
 }

--- a/backend/core/src/main/java/site/timecapsulearchive/core/domain/capsule/entity/Capsule.java
+++ b/backend/core/src/main/java/site/timecapsulearchive/core/domain/capsule/entity/Capsule.java
@@ -14,6 +14,7 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
+import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.util.List;
 import lombok.AccessLevel;
@@ -109,7 +110,7 @@ public class Capsule extends BaseEntity {
             return false;
         }
 
-        return dueDate.isAfter(ZonedDateTime.now());
+        return dueDate.isAfter(ZonedDateTime.now(ZoneId.of("UTC")));
     }
 
     public void open() {
@@ -118,5 +119,9 @@ public class Capsule extends BaseEntity {
 
     public boolean isTimeCapsule() {
         return dueDate != null;
+    }
+
+    public boolean canOpen() {
+        return dueDate == null || dueDate.isBefore(ZonedDateTime.now(ZoneId.of("UTC")));
     }
 }

--- a/backend/core/src/main/java/site/timecapsulearchive/core/domain/capsule/entity/Capsule.java
+++ b/backend/core/src/main/java/site/timecapsulearchive/core/domain/capsule/entity/Capsule.java
@@ -27,6 +27,7 @@ import site.timecapsulearchive.core.domain.capsule.exception.GroupCapsuleOpenNot
 import site.timecapsulearchive.core.domain.capsuleskin.entity.CapsuleSkin;
 import site.timecapsulearchive.core.domain.group.entity.Group;
 import site.timecapsulearchive.core.domain.member.entity.Member;
+import site.timecapsulearchive.core.global.common.supplier.ZonedDateTimeSupplier;
 import site.timecapsulearchive.core.global.entity.BaseEntity;
 
 @Entity
@@ -112,7 +113,7 @@ public class Capsule extends BaseEntity {
             return false;
         }
 
-        return dueDate.isAfter(ZonedDateTime.now(ZoneId.of("UTC")));
+        return dueDate.isAfter(ZonedDateTimeSupplier.utc().get());
     }
 
     public void open() {
@@ -124,7 +125,7 @@ public class Capsule extends BaseEntity {
     }
 
     public boolean canOpen() {
-        return dueDate == null || dueDate.isBefore(ZonedDateTime.now(ZoneId.of("UTC")));
+        return dueDate == null || dueDate.isBefore(ZonedDateTimeSupplier.utc().get());
     }
 
     public boolean isAllGroupMemberOpened(Long memberId, Long capsuleId) {

--- a/backend/core/src/main/java/site/timecapsulearchive/core/domain/capsule/entity/GroupCapsuleOpen.java
+++ b/backend/core/src/main/java/site/timecapsulearchive/core/domain/capsule/entity/GroupCapsuleOpen.java
@@ -53,4 +53,8 @@ public class GroupCapsuleOpen extends BaseEntity {
     public void open() {
         this.isOpened = Boolean.TRUE;
     }
+
+    public boolean matched(Long capsuleId, Long memberId) {
+        return capsule.getId().equals(capsuleId) && member.getId().equals(memberId);
+    }
 }

--- a/backend/core/src/main/java/site/timecapsulearchive/core/domain/capsule/generic_capsule/repository/CapsuleRepository.java
+++ b/backend/core/src/main/java/site/timecapsulearchive/core/domain/capsule/generic_capsule/repository/CapsuleRepository.java
@@ -23,4 +23,13 @@ public interface CapsuleRepository extends Repository<Capsule, Long> {
         @Param("memberId") Long memberId,
         @Param("capsuleId") Long capsuleId
     );
+
+    @Query("select c "
+        + "from Capsule c"
+        + " where c.id = :capsuleId and c.member.id = :memberId "
+        + "and c.type = 'GROUP' and c.group.id is not null")
+    Optional<Capsule> findGroupCapsuleByMemberIdAndCapsuleId(
+        @Param("memberId") Long memberId,
+        @Param("capsuleId") Long capsuleId
+    );
 }

--- a/backend/core/src/main/java/site/timecapsulearchive/core/domain/capsule/generic_capsule/repository/CapsuleRepository.java
+++ b/backend/core/src/main/java/site/timecapsulearchive/core/domain/capsule/generic_capsule/repository/CapsuleRepository.java
@@ -25,10 +25,11 @@ public interface CapsuleRepository extends Repository<Capsule, Long> {
     );
 
     @Query("select c "
-        + "from Capsule c"
-        + " where c.id = :capsuleId and c.member.id = :memberId "
-        + "and c.type = 'GROUP' and c.group.id is not null")
-    Optional<Capsule> findGroupCapsuleByMemberIdAndCapsuleId(
+        + "from Capsule c "
+        + "join fetch c.groupCapsuleOpens "
+        + "where c.id = :capsuleId and c.member.id = :memberId "
+        + "and c.type = 'GROUP' and c.group.id is not null and c.isOpened = false")
+    Optional<Capsule> findNotOpenedGroupCapsuleByMemberIdAndCapsuleId(
         @Param("memberId") Long memberId,
         @Param("capsuleId") Long capsuleId
     );

--- a/backend/core/src/main/java/site/timecapsulearchive/core/domain/capsule/group_capsule/api/GroupCapsuleApi.java
+++ b/backend/core/src/main/java/site/timecapsulearchive/core/domain/capsule/group_capsule/api/GroupCapsuleApi.java
@@ -22,6 +22,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 import site.timecapsulearchive.core.domain.capsule.group_capsule.data.reqeust.GroupCapsuleCreateRequest;
 import site.timecapsulearchive.core.domain.capsule.group_capsule.data.reqeust.GroupCapsuleUpdateRequest;
 import site.timecapsulearchive.core.domain.capsule.group_capsule.data.response.GroupCapsuleDetailResponse;
+import site.timecapsulearchive.core.domain.capsule.group_capsule.data.response.GroupCapsuleOpenStateResponse;
 import site.timecapsulearchive.core.domain.capsule.group_capsule.data.response.GroupCapsulePageResponse;
 import site.timecapsulearchive.core.domain.capsule.group_capsule.data.response.GroupCapsuleSummaryResponse;
 import site.timecapsulearchive.core.domain.capsule.group_capsule.data.response.MyGroupCapsuleSliceResponse;
@@ -172,7 +173,7 @@ public interface GroupCapsuleApi {
             content = @Content(schema = @Schema(implementation = ErrorResponse.class))
         )
     })
-    ResponseEntity<ApiSpec<String>> openCapsule(
+    ResponseEntity<ApiSpec<GroupCapsuleOpenStateResponse>> openCapsule(
         Long memberId,
 
         @Parameter(in = ParameterIn.PATH, description = "개봉할 그룹 캡슐 아이디", required = true)

--- a/backend/core/src/main/java/site/timecapsulearchive/core/domain/capsule/group_capsule/api/GroupCapsuleApiController.java
+++ b/backend/core/src/main/java/site/timecapsulearchive/core/domain/capsule/group_capsule/api/GroupCapsuleApiController.java
@@ -14,11 +14,13 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import site.timecapsulearchive.core.domain.capsule.group_capsule.data.dto.GroupCapsuleDetailDto;
+import site.timecapsulearchive.core.domain.capsule.group_capsule.data.dto.GroupCapsuleOpenStateDto;
 import site.timecapsulearchive.core.domain.capsule.group_capsule.data.dto.GroupCapsuleSummaryDto;
 import site.timecapsulearchive.core.domain.capsule.group_capsule.data.dto.MyGroupCapsuleDto;
 import site.timecapsulearchive.core.domain.capsule.group_capsule.data.reqeust.GroupCapsuleCreateRequest;
 import site.timecapsulearchive.core.domain.capsule.group_capsule.data.reqeust.GroupCapsuleUpdateRequest;
 import site.timecapsulearchive.core.domain.capsule.group_capsule.data.response.GroupCapsuleDetailResponse;
+import site.timecapsulearchive.core.domain.capsule.group_capsule.data.response.GroupCapsuleOpenStateResponse;
 import site.timecapsulearchive.core.domain.capsule.group_capsule.data.response.GroupCapsulePageResponse;
 import site.timecapsulearchive.core.domain.capsule.group_capsule.data.response.GroupCapsuleSummaryResponse;
 import site.timecapsulearchive.core.domain.capsule.group_capsule.data.response.MyGroupCapsuleSliceResponse;
@@ -139,13 +141,19 @@ public class GroupCapsuleApiController implements GroupCapsuleApi {
 
     @PostMapping("/{capsule_id}/open")
     @Override
-    public ResponseEntity<ApiSpec<String>> openCapsule(
+    public ResponseEntity<ApiSpec<GroupCapsuleOpenStateResponse>> openCapsule(
         @AuthenticationPrincipal final Long memberId,
         @PathVariable(value = "capsule_id") final Long capsuleId
     ) {
-        groupCapsuleService.openGroupCapsule(memberId, capsuleId);
+        GroupCapsuleOpenStateDto groupCapsuleOpenStateDto = groupCapsuleService.openGroupCapsule(
+            memberId, capsuleId);
 
-        return ResponseEntity.ok(ApiSpec.empty(SuccessCode.SUCCESS));
+        return ResponseEntity.ok(
+            ApiSpec.success(
+                SuccessCode.SUCCESS,
+                groupCapsuleOpenStateDto.toResponse()
+            )
+        );
     }
 
     @Override

--- a/backend/core/src/main/java/site/timecapsulearchive/core/domain/capsule/group_capsule/data/dto/CapsuleOpenStatus.java
+++ b/backend/core/src/main/java/site/timecapsulearchive/core/domain/capsule/group_capsule/data/dto/CapsuleOpenStatus.java
@@ -1,0 +1,14 @@
+package site.timecapsulearchive.core.domain.capsule.group_capsule.data.dto;
+
+import lombok.Getter;
+
+@Getter
+public enum CapsuleOpenStatus {
+    OPEN("캡슐이 개봉되었습니다."), NOT_OPEN("캡슐이 개봉되지 않았습니다.");
+
+    private final String statusMessage;
+
+    CapsuleOpenStatus(String statusMessage) {
+        this.statusMessage = statusMessage;
+    }
+}

--- a/backend/core/src/main/java/site/timecapsulearchive/core/domain/capsule/group_capsule/data/dto/GroupCapsuleOpenStateDto.java
+++ b/backend/core/src/main/java/site/timecapsulearchive/core/domain/capsule/group_capsule/data/dto/GroupCapsuleOpenStateDto.java
@@ -1,0 +1,23 @@
+package site.timecapsulearchive.core.domain.capsule.group_capsule.data.dto;
+
+import site.timecapsulearchive.core.domain.capsule.group_capsule.data.response.GroupCapsuleOpenStateResponse;
+
+public record GroupCapsuleOpenStateDto(
+    CapsuleOpenStatus capsuleOpenStatus
+) {
+
+    public static GroupCapsuleOpenStateDto opened() {
+        return new GroupCapsuleOpenStateDto(CapsuleOpenStatus.OPEN);
+    }
+
+    public static GroupCapsuleOpenStateDto notOpened() {
+        return new GroupCapsuleOpenStateDto(CapsuleOpenStatus.NOT_OPEN);
+    }
+
+    public GroupCapsuleOpenStateResponse toResponse() {
+        return new GroupCapsuleOpenStateResponse(
+            capsuleOpenStatus,
+            capsuleOpenStatus.getStatusMessage()
+        );
+    }
+}

--- a/backend/core/src/main/java/site/timecapsulearchive/core/domain/capsule/group_capsule/data/response/GroupCapsuleOpenStateResponse.java
+++ b/backend/core/src/main/java/site/timecapsulearchive/core/domain/capsule/group_capsule/data/response/GroupCapsuleOpenStateResponse.java
@@ -1,0 +1,10 @@
+package site.timecapsulearchive.core.domain.capsule.group_capsule.data.response;
+
+import site.timecapsulearchive.core.domain.capsule.group_capsule.data.dto.CapsuleOpenStatus;
+
+public record GroupCapsuleOpenStateResponse(
+    CapsuleOpenStatus capsuleOpenStatus,
+    String statusMessage
+) {
+
+}

--- a/backend/core/src/main/java/site/timecapsulearchive/core/domain/capsule/group_capsule/repository/GroupCapsuleOpenQueryRepository.java
+++ b/backend/core/src/main/java/site/timecapsulearchive/core/domain/capsule/group_capsule/repository/GroupCapsuleOpenQueryRepository.java
@@ -1,8 +1,5 @@
 package site.timecapsulearchive.core.domain.capsule.group_capsule.repository;
 
-import static site.timecapsulearchive.core.domain.capsule.entity.QGroupCapsuleOpen.groupCapsuleOpen;
-
-import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
 import java.sql.Timestamp;
@@ -20,7 +17,6 @@ import site.timecapsulearchive.core.domain.capsule.entity.Capsule;
 public class GroupCapsuleOpenQueryRepository {
 
     private final JdbcTemplate jdbcTemplate;
-    private final JPAQueryFactory jpaQueryFactory;
 
     public void bulkSave(final List<Long> groupMemberIds, final Capsule capsule) {
         jdbcTemplate.batchUpdate(
@@ -32,8 +28,10 @@ public class GroupCapsuleOpenQueryRepository {
             new BatchPreparedStatementSetter() {
                 @Override
                 public void setValues(PreparedStatement ps, int i) throws SQLException {
+                    boolean isOpened = capsule.getDueDate() == null;
+
                     ps.setNull(1, Types.BIGINT);
-                    ps.setBoolean(2, false);
+                    ps.setBoolean(2, isOpened);
                     ps.setLong(3, groupMemberIds.get(i));
                     ps.setLong(4, capsule.getId());
                     ps.setTimestamp(5, Timestamp.valueOf(ZonedDateTime.now().toLocalDateTime()));
@@ -46,13 +44,5 @@ public class GroupCapsuleOpenQueryRepository {
                 }
             }
         );
-    }
-
-    public List<Boolean> findIsOpenedByCapsuleId(final Long capsuleId) {
-        return jpaQueryFactory
-            .select(groupCapsuleOpen.isOpened)
-            .from(groupCapsuleOpen)
-            .where(groupCapsuleOpen.capsule.id.eq(capsuleId))
-            .fetch();
     }
 }

--- a/backend/core/src/main/java/site/timecapsulearchive/core/domain/capsule/group_capsule/repository/GroupCapsuleOpenRepository.java
+++ b/backend/core/src/main/java/site/timecapsulearchive/core/domain/capsule/group_capsule/repository/GroupCapsuleOpenRepository.java
@@ -1,5 +1,6 @@
 package site.timecapsulearchive.core.domain.capsule.group_capsule.repository;
 
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.repository.Repository;
 import site.timecapsulearchive.core.domain.capsule.entity.GroupCapsuleOpen;
@@ -9,4 +10,6 @@ public interface GroupCapsuleOpenRepository extends Repository<GroupCapsuleOpen,
     void save(GroupCapsuleOpen groupCapsuleOpen);
 
     Optional<GroupCapsuleOpen> findByMemberIdAndCapsuleId(Long memberId, Long capsuleId);
+
+    List<GroupCapsuleOpen> findByCapsuleId(Long capsuleId);
 }

--- a/backend/core/src/main/java/site/timecapsulearchive/core/domain/capsule/group_capsule/repository/GroupCapsuleOpenRepository.java
+++ b/backend/core/src/main/java/site/timecapsulearchive/core/domain/capsule/group_capsule/repository/GroupCapsuleOpenRepository.java
@@ -1,15 +1,9 @@
 package site.timecapsulearchive.core.domain.capsule.group_capsule.repository;
 
-import java.util.List;
-import java.util.Optional;
 import org.springframework.data.repository.Repository;
 import site.timecapsulearchive.core.domain.capsule.entity.GroupCapsuleOpen;
 
 public interface GroupCapsuleOpenRepository extends Repository<GroupCapsuleOpen, Long> {
 
     void save(GroupCapsuleOpen groupCapsuleOpen);
-
-    Optional<GroupCapsuleOpen> findByMemberIdAndCapsuleId(Long memberId, Long capsuleId);
-
-    List<GroupCapsuleOpen> findByCapsuleId(Long capsuleId);
 }

--- a/backend/core/src/main/java/site/timecapsulearchive/core/domain/capsule/group_capsule/service/GroupCapsuleService.java
+++ b/backend/core/src/main/java/site/timecapsulearchive/core/domain/capsule/group_capsule/service/GroupCapsuleService.java
@@ -18,7 +18,6 @@ import site.timecapsulearchive.core.domain.capsule.group_capsule.data.dto.GroupC
 import site.timecapsulearchive.core.domain.capsule.group_capsule.data.dto.GroupCapsuleDetailDto;
 import site.timecapsulearchive.core.domain.capsule.group_capsule.data.dto.GroupCapsuleSummaryDto;
 import site.timecapsulearchive.core.domain.capsule.group_capsule.data.dto.MyGroupCapsuleDto;
-import site.timecapsulearchive.core.domain.capsule.group_capsule.repository.GroupCapsuleOpenQueryRepository;
 import site.timecapsulearchive.core.domain.capsule.group_capsule.repository.GroupCapsuleOpenRepository;
 import site.timecapsulearchive.core.domain.capsule.group_capsule.repository.GroupCapsuleQueryRepository;
 import site.timecapsulearchive.core.domain.capsuleskin.entity.CapsuleSkin;
@@ -106,7 +105,7 @@ public class GroupCapsuleService {
         Capsule groupCapsule = capsuleRepository.findGroupCapsuleByMemberIdAndCapsuleId(memberId, capsuleId)
             .orElseThrow(CapsuleNotFondException::new);
 
-        if (groupCapsule.getDueDate() == null) {
+        if (!groupCapsule.isTimeCapsule()) {
             groupCapsule.open();
             return;
         }

--- a/backend/core/src/main/java/site/timecapsulearchive/core/global/common/supplier/ZonedDateTimeSupplier.java
+++ b/backend/core/src/main/java/site/timecapsulearchive/core/global/common/supplier/ZonedDateTimeSupplier.java
@@ -1,0 +1,14 @@
+package site.timecapsulearchive.core.global.common.supplier;
+
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.util.function.Supplier;
+
+public class ZonedDateTimeSupplier {
+
+    private static final String TIME_ZONE = "UTC";
+
+    public static Supplier<ZonedDateTime> utc() {
+        return () -> ZonedDateTime.now(ZoneId.of(TIME_ZONE));
+    }
+}

--- a/backend/core/src/main/java/site/timecapsulearchive/core/global/error/ErrorCode.java
+++ b/backend/core/src/main/java/site/timecapsulearchive/core/global/error/ErrorCode.java
@@ -57,6 +57,7 @@ public enum ErrorCode {
     CAPSULE_NOT_FOUND_ERROR(404, "CAPSULE-001", "캡슐을 찾지 못하였습니다."),
     NO_CAPSULE_AUTHORITY_ERROR(403, "CAPSULE-002", "캡슐에 접근 권한이 없습니다."),
     GROUP_CAPSULE_OPEN_NOT_FOUND_ERROR(404, "CAPSULE-003", "그룹 캡슐 개봉상태를 찾을 수 없습니다."),
+    CAPSULE_OPEN_STATE_ERROR(400, "CAPSULE-004", "캡슐을 개봉할 수 없는 상태입니다."),
 
     //friend
     FRIEND_NOT_FOUND_ERROR(404, "FRIEND-001", "친구를 찾지 못하였습니다"),

--- a/backend/core/src/test/java/site/timecapsulearchive/core/common/fixture/domain/CapsuleFixture.java
+++ b/backend/core/src/test/java/site/timecapsulearchive/core/common/fixture/domain/CapsuleFixture.java
@@ -15,6 +15,7 @@ import site.timecapsulearchive.core.domain.capsule.entity.GroupCapsuleOpen;
 import site.timecapsulearchive.core.domain.capsuleskin.entity.CapsuleSkin;
 import site.timecapsulearchive.core.domain.group.entity.Group;
 import site.timecapsulearchive.core.domain.member.entity.Member;
+import site.timecapsulearchive.core.global.common.supplier.ZonedDateTimeSupplier;
 import site.timecapsulearchive.core.global.geography.GeoTransformManager;
 
 public class CapsuleFixture {
@@ -33,7 +34,7 @@ public class CapsuleFixture {
 
     public static Capsule capsule(Member member, CapsuleSkin capsuleSkin, CapsuleType capsuleType) {
         return Capsule.builder()
-            .dueDate(ZonedDateTime.now())
+            .dueDate(ZonedDateTimeSupplier.utc().get())
             .title("testTitle")
             .content("testContent")
             .type(capsuleType)
@@ -68,7 +69,7 @@ public class CapsuleFixture {
      */
     public static Capsule groupCapsule(Member member, CapsuleSkin capsuleSkin, Group group) {
         return Capsule.builder()
-            .dueDate(ZonedDateTime.now())
+            .dueDate(ZonedDateTimeSupplier.utc().get())
             .title("testTitle")
             .content("testContent")
             .type(CapsuleType.GROUP)
@@ -132,7 +133,7 @@ public class CapsuleFixture {
         List<Member> groupMembers
     ) {
         CapsuleBuilder capsuleBuilder = getCapsuleBuilder(memberId);
-        Capsule capsule = capsuleBuilder.dueDate(ZonedDateTime.now(ZoneId.of("UTC")))
+        Capsule capsule = capsuleBuilder.dueDate(ZonedDateTimeSupplier.utc().get())
             .build();
 
         List<GroupCapsuleOpen> groupCapsuleOpens = GroupCapsuleOpenFixture.groupCapsuleOpens(false,
@@ -149,7 +150,7 @@ public class CapsuleFixture {
         List<Member> groupMembers
     ) {
         CapsuleBuilder capsuleBuilder = getCapsuleBuilder(memberId);
-        Capsule capsule = capsuleBuilder.dueDate(ZonedDateTime.now(ZoneId.of("UTC")))
+        Capsule capsule = capsuleBuilder.dueDate(ZonedDateTimeSupplier.utc().get())
             .build();
 
         List<GroupCapsuleOpen> groupCapsuleOpens = GroupCapsuleOpenFixture.groupCapsuleOpensNotAllOpened(
@@ -164,7 +165,7 @@ public class CapsuleFixture {
         Long capsuleId
     ) {
         CapsuleBuilder capsuleBuilder = getCapsuleBuilder(memberId);
-        Capsule capsule = capsuleBuilder.dueDate(ZonedDateTime.now(ZoneId.of("UTC")))
+        Capsule capsule = capsuleBuilder.dueDate(ZonedDateTimeSupplier.utc().get())
             .build();
 
         setFieldValue(capsule, "id", capsuleId);
@@ -178,7 +179,7 @@ public class CapsuleFixture {
         List<Member> groupMembers
     ) {
         CapsuleBuilder capsuleBuilder = getCapsuleBuilder(memberId);
-        Capsule capsule = capsuleBuilder.dueDate(ZonedDateTime.now(ZoneId.of("UTC")))
+        Capsule capsule = capsuleBuilder.dueDate(ZonedDateTimeSupplier.utc().get())
             .build();
 
         List<GroupCapsuleOpen> groupCapsuleOpens = GroupCapsuleOpenFixture.groupCapsuleOpens(true,
@@ -195,7 +196,7 @@ public class CapsuleFixture {
         List<Member> groupMembers
     ) {
         CapsuleBuilder capsuleBuilder = getCapsuleBuilder(memberId);
-        Capsule capsule = capsuleBuilder.dueDate(ZonedDateTime.now(ZoneId.of("UTC")))
+        Capsule capsule = capsuleBuilder.dueDate(ZonedDateTimeSupplier.utc().get())
             .build();
 
         List<GroupCapsuleOpen> groupCapsuleOpens = GroupCapsuleOpenFixture.groupCapsuleOpensNotOpenSpecificMemberId(
@@ -208,7 +209,7 @@ public class CapsuleFixture {
 
     public static Optional<Capsule> groupCapsuleAlreadyOpen(Long memberId, Long capsuleId) {
         CapsuleBuilder capsuleBuilder = getCapsuleBuilder(memberId);
-        Capsule capsule = capsuleBuilder.dueDate(ZonedDateTime.now(ZoneId.of("UTC")))
+        Capsule capsule = capsuleBuilder.dueDate(ZonedDateTimeSupplier.utc().get())
             .build();
 
         setFieldValue(capsule, "id", capsuleId);

--- a/backend/core/src/test/java/site/timecapsulearchive/core/common/fixture/domain/CapsuleFixture.java
+++ b/backend/core/src/test/java/site/timecapsulearchive/core/common/fixture/domain/CapsuleFixture.java
@@ -115,4 +115,31 @@ public class CapsuleFixture {
         field.setAccessible(true);
         field.set(instance, value);
     }
+
+    public static Capsule notGroupTimeCapsuleWithCapsuleId(
+        Member member,
+        CapsuleSkin capsuleSkin,
+        Group group,
+        Long capsuleId,
+        ZonedDateTime now
+    ) {
+        Capsule capsule = Capsule.builder()
+            .dueDate(now)
+            .title("testTitle")
+            .content("testContent")
+            .type(CapsuleType.GROUP)
+            .address(getTestAddress())
+            .point(geoTransformManager.changePoint4326To3857(TEST_LATITUDE, TEST_LONGITUDE))
+            .member(member)
+            .capsuleSkin(capsuleSkin)
+            .group(group)
+            .build();
+
+        try {
+            setFieldValue(capsule, "id", capsuleId);
+            return capsule;
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
 }

--- a/backend/core/src/test/java/site/timecapsulearchive/core/common/fixture/domain/CapsuleFixture.java
+++ b/backend/core/src/test/java/site/timecapsulearchive/core/common/fixture/domain/CapsuleFixture.java
@@ -1,5 +1,6 @@
 package site.timecapsulearchive.core.common.fixture.domain;
 
+import java.lang.reflect.Field;
 import java.time.ZonedDateTime;
 import java.util.List;
 import java.util.stream.IntStream;
@@ -90,5 +91,28 @@ public class CapsuleFixture {
             .capsuleSkin(capsuleSkin)
             .group(group)
             .build();
+    }
+
+    public static Capsule groupCapsuleWithCapsuleId(
+        Member member,
+        CapsuleSkin capsuleSkin,
+        Group group,
+        Long capsuleId
+    ) {
+        try {
+            Capsule capsule = groupCapsule(member, capsuleSkin, group);
+
+            setFieldValue(capsule, "id", capsuleId);
+            return capsule;
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private static void setFieldValue(Object instance, String fieldName, Object value)
+        throws NoSuchFieldException, IllegalAccessException {
+        Field field = instance.getClass().getDeclaredField(fieldName);
+        field.setAccessible(true);
+        field.set(instance, value);
     }
 }

--- a/backend/core/src/test/java/site/timecapsulearchive/core/common/fixture/domain/GroupCapsuleOpenFixture.java
+++ b/backend/core/src/test/java/site/timecapsulearchive/core/common/fixture/domain/GroupCapsuleOpenFixture.java
@@ -1,7 +1,10 @@
 package site.timecapsulearchive.core.common.fixture.domain;
 
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.Stream;
 import site.timecapsulearchive.core.domain.capsule.entity.Capsule;
 import site.timecapsulearchive.core.domain.capsule.entity.CapsuleType;
 import site.timecapsulearchive.core.domain.capsule.entity.GroupCapsuleOpen;
@@ -32,5 +35,20 @@ public class GroupCapsuleOpenFixture {
                 Boolean.FALSE
             )
         );
+    }
+
+    public static List<GroupCapsuleOpen> groupCapsuleOpensNotAllOpened(
+        Capsule capsule,
+        List<Member> groupMembers
+    ) {
+        int mid = groupMembers.size() / 2;
+        List<GroupCapsuleOpen> opened = groupCapsuleOpens(true, capsule,
+            groupMembers.subList(0, mid));
+        List<GroupCapsuleOpen> notOpened = groupCapsuleOpens(false, capsule,
+            groupMembers.subList(mid, groupMembers.size() - 1));
+
+        return Stream.of(opened, notOpened)
+            .flatMap(Collection::stream)
+            .toList();
     }
 }

--- a/backend/core/src/test/java/site/timecapsulearchive/core/common/fixture/domain/GroupCapsuleOpenFixture.java
+++ b/backend/core/src/test/java/site/timecapsulearchive/core/common/fixture/domain/GroupCapsuleOpenFixture.java
@@ -51,4 +51,30 @@ public class GroupCapsuleOpenFixture {
             .flatMap(Collection::stream)
             .toList();
     }
+
+    public static List<GroupCapsuleOpen> groupCapsuleOpensNotOpenSpecificMemberId(
+        Capsule capsule,
+        List<Member> groupMembers,
+        Long memberId
+    ) {
+        List<Member> filteredMember = new ArrayList<>();
+        Member specificMember = null;
+        for (Member member : groupMembers) {
+            if (member.getId().equals(memberId)) {
+                specificMember = member;
+            } else {
+                filteredMember.add(member);
+            }
+        }
+
+        if (specificMember == null) {
+            throw new RuntimeException("멤버 리스트에 memberId를 가진 멤버가 존재하지 않습니다.");
+        }
+
+        List<GroupCapsuleOpen> result = new ArrayList<>();
+        result.add(GroupCapsuleOpen.createOf(specificMember, capsule, false));
+        result.addAll(groupCapsuleOpens(true, capsule, filteredMember));
+
+        return result;
+    }
 }

--- a/backend/core/src/test/java/site/timecapsulearchive/core/domain/capsule/group_capsule/repository/GroupCapsuleOpenQueryRepositoryTest.java
+++ b/backend/core/src/test/java/site/timecapsulearchive/core/domain/capsule/group_capsule/repository/GroupCapsuleOpenQueryRepositoryTest.java
@@ -37,13 +37,11 @@ class GroupCapsuleOpenQueryRepositoryTest extends RepositoryTest {
     private List<GroupCapsuleOpen> groupCapsuleOpens;
 
     public GroupCapsuleOpenQueryRepositoryTest(
-        JPAQueryFactory jpaQueryFactory,
         JdbcTemplate jdbcTemplate,
         DataSource dataSource
     ) {
         this.namedParameterJdbcTemplate = new NamedParameterJdbcTemplate(dataSource);
-        this.groupCapsuleOpenRepository = new GroupCapsuleOpenQueryRepository(jdbcTemplate,
-            jpaQueryFactory);
+        this.groupCapsuleOpenRepository = new GroupCapsuleOpenQueryRepository(jdbcTemplate);
     }
 
     @Transactional


### PR DESCRIPTION
## 작업 내용 (Content)
- 그룹 캡슐 개봉 로직 수정

## 링크 (Links)
- #470

## 기타 사항 (Etc)


## Merge 전 필요 작업 (Checklist before merge)
1. 그룹 캡슐 생성 전 그룹 캡슐의 개봉일이 null이면 groupCapsuleOpen을 전부 true로 설정
2. 개봉 시 캡슐 개봉일이 null이면 캡슐 개봉 상태 true로 변경
3. 개봉일이 null이 아닌 경우 현재 일치하는 멤버와 캡슐 아이디로 그룹 캡슐 개봉 상태 업데이트
4. 3 후 그룹 캡슐 개봉이 전부 개봉된 상태이면 캡슐 개봉

## 희망 리뷰 완료 일 (Expected due date)