### PR TITLE
feat : 그룹 캡슐 목록 조회 #476

### DIFF
--- a/backend/core/src/main/java/site/timecapsulearchive/core/domain/capsule/group_capsule/api/GroupCapsuleApi.java
+++ b/backend/core/src/main/java/site/timecapsulearchive/core/domain/capsule/group_capsule/api/GroupCapsuleApi.java
@@ -112,6 +112,11 @@ public interface GroupCapsuleApi {
         @ApiResponse(
             responseCode = "200",
             description = "처리 완료"
+        ),
+        @ApiResponse(
+            responseCode = "403",
+            description = "그룹에 대한 권한이 없는 경우 발생한다",
+            content = @Content(schema = @Schema(implementation = ErrorResponse.class))
         )
     })
     ResponseEntity<ApiSpec<Slice<CapsuleBasicInfoDto>>> getGroupCapsules(

--- a/backend/core/src/main/java/site/timecapsulearchive/core/domain/capsule/group_capsule/api/GroupCapsuleApi.java
+++ b/backend/core/src/main/java/site/timecapsulearchive/core/domain/capsule/group_capsule/api/GroupCapsuleApi.java
@@ -9,21 +9,19 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import jakarta.validation.Valid;
-import jakarta.validation.constraints.NotNull;
 import java.time.ZonedDateTime;
 import org.hibernate.validator.constraints.Range;
+import org.springframework.data.domain.Slice;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
-import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestParam;
+import site.timecapsulearchive.core.domain.capsule.data.dto.CapsuleBasicInfoDto;
 import site.timecapsulearchive.core.domain.capsule.group_capsule.data.reqeust.GroupCapsuleCreateRequest;
 import site.timecapsulearchive.core.domain.capsule.group_capsule.data.reqeust.GroupCapsuleUpdateRequest;
 import site.timecapsulearchive.core.domain.capsule.group_capsule.data.response.GroupCapsuleDetailResponse;
 import site.timecapsulearchive.core.domain.capsule.group_capsule.data.response.GroupCapsuleOpenStateResponse;
-import site.timecapsulearchive.core.domain.capsule.group_capsule.data.response.GroupCapsulePageResponse;
 import site.timecapsulearchive.core.domain.capsule.group_capsule.data.response.GroupCapsuleSummaryResponse;
 import site.timecapsulearchive.core.domain.capsule.group_capsule.data.response.MyGroupCapsuleSliceResponse;
 import site.timecapsulearchive.core.global.common.response.ApiSpec;
@@ -116,14 +114,14 @@ public interface GroupCapsuleApi {
             description = "처리 완료"
         )
     })
-    ResponseEntity<GroupCapsulePageResponse> getGroupCapsules(
+    ResponseEntity<ApiSpec<Slice<CapsuleBasicInfoDto>>> getGroupCapsules(
         Long memberId,
 
         @Parameter(in = ParameterIn.QUERY, description = "그룹 아이디", required = true)
         Long groupId,
 
         @Parameter(in = ParameterIn.QUERY, description = "페이지 크기", required = true)
-        Long size,
+        int size,
 
         @Parameter(in = ParameterIn.QUERY, description = "마지막 캡슐 아이디", required = true)
         Long capsuleId

--- a/backend/core/src/main/java/site/timecapsulearchive/core/domain/capsule/group_capsule/api/GroupCapsuleApi.java
+++ b/backend/core/src/main/java/site/timecapsulearchive/core/domain/capsule/group_capsule/api/GroupCapsuleApi.java
@@ -129,7 +129,7 @@ public interface GroupCapsuleApi {
         int size,
 
         @Parameter(in = ParameterIn.QUERY, description = "마지막 캡슐 아이디", required = true)
-        Long capsuleId
+        Long lastCapsuleId
     );
 
     @Operation(

--- a/backend/core/src/main/java/site/timecapsulearchive/core/domain/capsule/group_capsule/api/GroupCapsuleApi.java
+++ b/backend/core/src/main/java/site/timecapsulearchive/core/domain/capsule/group_capsule/api/GroupCapsuleApi.java
@@ -11,17 +11,16 @@ import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import jakarta.validation.Valid;
 import java.time.ZonedDateTime;
 import org.hibernate.validator.constraints.Range;
-import org.springframework.data.domain.Slice;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
-import site.timecapsulearchive.core.domain.capsule.data.dto.CapsuleBasicInfoDto;
 import site.timecapsulearchive.core.domain.capsule.group_capsule.data.reqeust.GroupCapsuleCreateRequest;
 import site.timecapsulearchive.core.domain.capsule.group_capsule.data.reqeust.GroupCapsuleUpdateRequest;
 import site.timecapsulearchive.core.domain.capsule.group_capsule.data.response.GroupCapsuleDetailResponse;
 import site.timecapsulearchive.core.domain.capsule.group_capsule.data.response.GroupCapsuleOpenStateResponse;
+import site.timecapsulearchive.core.domain.capsule.group_capsule.data.response.GroupCapsuleSliceResponse;
 import site.timecapsulearchive.core.domain.capsule.group_capsule.data.response.GroupCapsuleSummaryResponse;
 import site.timecapsulearchive.core.domain.capsule.group_capsule.data.response.MyGroupCapsuleSliceResponse;
 import site.timecapsulearchive.core.global.common.response.ApiSpec;
@@ -119,7 +118,7 @@ public interface GroupCapsuleApi {
             content = @Content(schema = @Schema(implementation = ErrorResponse.class))
         )
     })
-    ResponseEntity<ApiSpec<Slice<CapsuleBasicInfoDto>>> getGroupCapsules(
+    ResponseEntity<ApiSpec<GroupCapsuleSliceResponse>> getGroupCapsules(
         Long memberId,
 
         @Parameter(in = ParameterIn.QUERY, description = "그룹 아이디", required = true)

--- a/backend/core/src/main/java/site/timecapsulearchive/core/domain/capsule/group_capsule/api/GroupCapsuleApi.java
+++ b/backend/core/src/main/java/site/timecapsulearchive/core/domain/capsule/group_capsule/api/GroupCapsuleApi.java
@@ -116,19 +116,17 @@ public interface GroupCapsuleApi {
             description = "처리 완료"
         )
     })
-    @GetMapping(
-        value = "/groups/{group_id}/capsules",
-        produces = {"application/json"}
-    )
     ResponseEntity<GroupCapsulePageResponse> getGroupCapsules(
-        @Parameter(in = ParameterIn.PATH, description = "그룹 아이디", required = true, schema = @Schema())
-        @PathVariable("group_id") Long groupId,
+        Long memberId,
 
-        @Parameter(in = ParameterIn.QUERY, description = "페이지 크기", required = true, schema = @Schema())
-        @NotNull @Valid @RequestParam(value = "size") Long size,
+        @Parameter(in = ParameterIn.QUERY, description = "그룹 아이디", required = true)
+        Long groupId,
 
-        @Parameter(in = ParameterIn.QUERY, description = "마지막 캡슐 아이디", required = true, schema = @Schema())
-        @NotNull @Valid @RequestParam(value = "capsule_id") Long capsuleId
+        @Parameter(in = ParameterIn.QUERY, description = "페이지 크기", required = true)
+        Long size,
+
+        @Parameter(in = ParameterIn.QUERY, description = "마지막 캡슐 아이디", required = true)
+        Long capsuleId
     );
 
     @Operation(

--- a/backend/core/src/main/java/site/timecapsulearchive/core/domain/capsule/group_capsule/api/GroupCapsuleApiController.java
+++ b/backend/core/src/main/java/site/timecapsulearchive/core/domain/capsule/group_capsule/api/GroupCapsuleApiController.java
@@ -108,9 +108,16 @@ public class GroupCapsuleApiController implements GroupCapsuleApi {
         );
     }
 
+    @GetMapping(
+        produces = {"application/json"}
+    )
     @Override
-    public ResponseEntity<GroupCapsulePageResponse> getGroupCapsules(Long groupId, Long size,
-        Long capsuleId) {
+    public ResponseEntity<GroupCapsulePageResponse> getGroupCapsules(
+        @AuthenticationPrincipal final Long memberId,
+        @RequestParam("group_id") final Long groupId,
+        @RequestParam("size") final Long size,
+        @RequestParam("capsuleId") final Long capsuleId
+    ) {
         return null;
     }
 

--- a/backend/core/src/main/java/site/timecapsulearchive/core/domain/capsule/group_capsule/api/GroupCapsuleApiController.java
+++ b/backend/core/src/main/java/site/timecapsulearchive/core/domain/capsule/group_capsule/api/GroupCapsuleApiController.java
@@ -22,6 +22,7 @@ import site.timecapsulearchive.core.domain.capsule.group_capsule.data.reqeust.Gr
 import site.timecapsulearchive.core.domain.capsule.group_capsule.data.reqeust.GroupCapsuleUpdateRequest;
 import site.timecapsulearchive.core.domain.capsule.group_capsule.data.response.GroupCapsuleDetailResponse;
 import site.timecapsulearchive.core.domain.capsule.group_capsule.data.response.GroupCapsuleOpenStateResponse;
+import site.timecapsulearchive.core.domain.capsule.group_capsule.data.response.GroupCapsuleSliceResponse;
 import site.timecapsulearchive.core.domain.capsule.group_capsule.data.response.GroupCapsuleSummaryResponse;
 import site.timecapsulearchive.core.domain.capsule.group_capsule.data.response.MyGroupCapsuleSliceResponse;
 import site.timecapsulearchive.core.domain.capsule.group_capsule.facade.GroupCapsuleFacade;
@@ -112,13 +113,14 @@ public class GroupCapsuleApiController implements GroupCapsuleApi {
         produces = {"application/json"}
     )
     @Override
-    public ResponseEntity<ApiSpec<Slice<CapsuleBasicInfoDto>>> getGroupCapsules(
+    public ResponseEntity<ApiSpec<GroupCapsuleSliceResponse>> getGroupCapsules(
         @AuthenticationPrincipal final Long memberId,
         @RequestParam("group_id") final Long groupId,
         @RequestParam("size") final int size,
-        @RequestParam("last_capsule_id") final Long lastCapsuleId
+        @RequestParam(value = "last_capsule_id", required = false) final Long lastCapsuleId
     ) {
-        final GroupCapsuleSliceRequestDto dto = GroupCapsuleSliceRequestDto.createOf(memberId, groupId,
+        final GroupCapsuleSliceRequestDto dto = GroupCapsuleSliceRequestDto.createOf(memberId,
+            groupId,
             size, lastCapsuleId);
 
         final Slice<CapsuleBasicInfoDto> groupCapsuleSlice = groupCapsuleService.findGroupCapsuleSlice(
@@ -127,7 +129,11 @@ public class GroupCapsuleApiController implements GroupCapsuleApi {
         return ResponseEntity.ok(
             ApiSpec.success(
                 SuccessCode.SUCCESS,
-                groupCapsuleSlice
+                GroupCapsuleSliceResponse.create(
+                    groupCapsuleSlice.getContent(),
+                    groupCapsuleSlice.hasNext(),
+                    s3PreSignedUrlManager::getS3PreSignedUrlForGet
+                )
             )
         );
     }

--- a/backend/core/src/main/java/site/timecapsulearchive/core/domain/capsule/group_capsule/api/GroupCapsuleApiController.java
+++ b/backend/core/src/main/java/site/timecapsulearchive/core/domain/capsule/group_capsule/api/GroupCapsuleApiController.java
@@ -116,10 +116,10 @@ public class GroupCapsuleApiController implements GroupCapsuleApi {
         @AuthenticationPrincipal final Long memberId,
         @RequestParam("group_id") final Long groupId,
         @RequestParam("size") final int size,
-        @RequestParam("capsuleId") final Long capsuleId
+        @RequestParam("last_capsule_id") final Long lastCapsuleId
     ) {
         final GroupCapsuleSliceRequestDto dto = GroupCapsuleSliceRequestDto.createOf(memberId, groupId,
-            size, capsuleId);
+            size, lastCapsuleId);
 
         final Slice<CapsuleBasicInfoDto> groupCapsuleSlice = groupCapsuleService.findGroupCapsuleSlice(
             dto);

--- a/backend/core/src/main/java/site/timecapsulearchive/core/domain/capsule/group_capsule/api/GroupCapsuleApiController.java
+++ b/backend/core/src/main/java/site/timecapsulearchive/core/domain/capsule/group_capsule/api/GroupCapsuleApiController.java
@@ -16,12 +16,12 @@ import org.springframework.web.bind.annotation.RestController;
 import site.timecapsulearchive.core.domain.capsule.data.dto.CapsuleBasicInfoDto;
 import site.timecapsulearchive.core.domain.capsule.group_capsule.data.dto.GroupCapsuleDetailDto;
 import site.timecapsulearchive.core.domain.capsule.group_capsule.data.dto.GroupCapsuleOpenStateDto;
+import site.timecapsulearchive.core.domain.capsule.group_capsule.data.dto.GroupCapsuleSliceRequestDto;
 import site.timecapsulearchive.core.domain.capsule.group_capsule.data.dto.GroupCapsuleSummaryDto;
 import site.timecapsulearchive.core.domain.capsule.group_capsule.data.reqeust.GroupCapsuleCreateRequest;
 import site.timecapsulearchive.core.domain.capsule.group_capsule.data.reqeust.GroupCapsuleUpdateRequest;
 import site.timecapsulearchive.core.domain.capsule.group_capsule.data.response.GroupCapsuleDetailResponse;
 import site.timecapsulearchive.core.domain.capsule.group_capsule.data.response.GroupCapsuleOpenStateResponse;
-import site.timecapsulearchive.core.domain.capsule.group_capsule.data.response.GroupCapsulePageResponse;
 import site.timecapsulearchive.core.domain.capsule.group_capsule.data.response.GroupCapsuleSummaryResponse;
 import site.timecapsulearchive.core.domain.capsule.group_capsule.data.response.MyGroupCapsuleSliceResponse;
 import site.timecapsulearchive.core.domain.capsule.group_capsule.facade.GroupCapsuleFacade;
@@ -112,13 +112,24 @@ public class GroupCapsuleApiController implements GroupCapsuleApi {
         produces = {"application/json"}
     )
     @Override
-    public ResponseEntity<GroupCapsulePageResponse> getGroupCapsules(
+    public ResponseEntity<ApiSpec<Slice<CapsuleBasicInfoDto>>> getGroupCapsules(
         @AuthenticationPrincipal final Long memberId,
         @RequestParam("group_id") final Long groupId,
-        @RequestParam("size") final Long size,
+        @RequestParam("size") final int size,
         @RequestParam("capsuleId") final Long capsuleId
     ) {
-        return null;
+        final GroupCapsuleSliceRequestDto dto = GroupCapsuleSliceRequestDto.createOf(memberId, groupId,
+            size, capsuleId);
+
+        final Slice<CapsuleBasicInfoDto> groupCapsuleSlice = groupCapsuleService.findGroupCapsuleSlice(
+            dto);
+
+        return ResponseEntity.ok(
+            ApiSpec.success(
+                SuccessCode.SUCCESS,
+                groupCapsuleSlice
+            )
+        );
     }
 
     @GetMapping(value = "/my", produces = {"application/json"})

--- a/backend/core/src/main/java/site/timecapsulearchive/core/domain/capsule/group_capsule/data/dto/GroupCapsuleSliceRequestDto.java
+++ b/backend/core/src/main/java/site/timecapsulearchive/core/domain/capsule/group_capsule/data/dto/GroupCapsuleSliceRequestDto.java
@@ -4,15 +4,15 @@ public record GroupCapsuleSliceRequestDto(
     Long memberId,
     Long groupId,
     int size,
-    Long capsuleId
+    Long lastCapsuleId
 ) {
 
     public static GroupCapsuleSliceRequestDto createOf(
         final Long memberId,
         final Long groupId,
         final int size,
-        final Long capsuleId
+        final Long lastCapsuleId
     ) {
-        return new GroupCapsuleSliceRequestDto(memberId, groupId, size, capsuleId);
+        return new GroupCapsuleSliceRequestDto(memberId, groupId, size, lastCapsuleId);
     }
 }

--- a/backend/core/src/main/java/site/timecapsulearchive/core/domain/capsule/group_capsule/data/dto/GroupCapsuleSliceRequestDto.java
+++ b/backend/core/src/main/java/site/timecapsulearchive/core/domain/capsule/group_capsule/data/dto/GroupCapsuleSliceRequestDto.java
@@ -1,0 +1,18 @@
+package site.timecapsulearchive.core.domain.capsule.group_capsule.data.dto;
+
+public record GroupCapsuleSliceRequestDto(
+    Long memberId,
+    Long groupId,
+    int size,
+    Long capsuleId
+) {
+
+    public static GroupCapsuleSliceRequestDto createOf(
+        final Long memberId,
+        final Long groupId,
+        final int size,
+        final Long capsuleId
+    ) {
+        return new GroupCapsuleSliceRequestDto(memberId, groupId, size, capsuleId);
+    }
+}

--- a/backend/core/src/main/java/site/timecapsulearchive/core/domain/capsule/group_capsule/data/response/GroupCapsuleSliceResponse.java
+++ b/backend/core/src/main/java/site/timecapsulearchive/core/domain/capsule/group_capsule/data/response/GroupCapsuleSliceResponse.java
@@ -1,0 +1,30 @@
+package site.timecapsulearchive.core.domain.capsule.group_capsule.data.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+import java.util.function.UnaryOperator;
+import site.timecapsulearchive.core.domain.capsule.data.dto.CapsuleBasicInfoDto;
+import site.timecapsulearchive.core.domain.capsule.data.response.CapsuleBasicInfoResponse;
+
+@Schema(description = "그룹 캡슐 목록 응답")
+public record GroupCapsuleSliceResponse(
+
+    @Schema(description = "캡슐 기본 정보 목록")
+    List<CapsuleBasicInfoResponse> capsuleBasicInfos,
+
+    @Schema(description = "다음 페이지 유무")
+    boolean hasNext
+) {
+
+    public static GroupCapsuleSliceResponse create(
+        final List<CapsuleBasicInfoDto> dtos,
+        final boolean hasNext,
+        final UnaryOperator<String> preSignUrlFunction
+    ) {
+        List<CapsuleBasicInfoResponse> capsuleBasicInfoResponses = dtos.stream()
+            .map(dto -> dto.toResponse(preSignUrlFunction))
+            .toList();
+
+        return new GroupCapsuleSliceResponse(capsuleBasicInfoResponses, hasNext);
+    }
+}

--- a/backend/core/src/main/java/site/timecapsulearchive/core/domain/capsule/group_capsule/repository/GroupCapsuleQueryRepository.java
+++ b/backend/core/src/main/java/site/timecapsulearchive/core/domain/capsule/group_capsule/repository/GroupCapsuleQueryRepository.java
@@ -196,7 +196,7 @@ public class GroupCapsuleQueryRepository {
             )
             .from(capsule)
             .where(capsule.group.id.eq(dto.groupId())
-                .and(capsuleIdPagingCursorCondition(dto.capsuleId())))
+                .and(capsuleIdPagingCursorCondition(dto.lastCapsuleId())))
             .limit(dto.size() + 1)
             .fetch();
 

--- a/backend/core/src/main/java/site/timecapsulearchive/core/domain/capsule/group_capsule/repository/GroupCapsuleQueryRepository.java
+++ b/backend/core/src/main/java/site/timecapsulearchive/core/domain/capsule/group_capsule/repository/GroupCapsuleQueryRepository.java
@@ -197,6 +197,7 @@ public class GroupCapsuleQueryRepository {
             .from(capsule)
             .where(capsule.group.id.eq(dto.groupId())
                 .and(capsuleIdPagingCursorCondition(dto.lastCapsuleId())))
+            .orderBy(capsule.id.desc())
             .limit(dto.size() + 1)
             .fetch();
 

--- a/backend/core/src/main/java/site/timecapsulearchive/core/domain/capsule/group_capsule/repository/GroupCapsuleQueryRepository.java
+++ b/backend/core/src/main/java/site/timecapsulearchive/core/domain/capsule/group_capsule/repository/GroupCapsuleQueryRepository.java
@@ -10,6 +10,7 @@ import static site.timecapsulearchive.core.domain.capsuleskin.entity.QCapsuleSki
 import static site.timecapsulearchive.core.domain.member.entity.QMember.member;
 
 import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.core.types.dsl.StringExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
@@ -24,6 +25,7 @@ import site.timecapsulearchive.core.domain.capsule.entity.CapsuleType;
 import site.timecapsulearchive.core.domain.capsule.generic_capsule.data.dto.CapsuleDetailDto;
 import site.timecapsulearchive.core.domain.capsule.generic_capsule.data.dto.CapsuleSummaryDto;
 import site.timecapsulearchive.core.domain.capsule.group_capsule.data.dto.GroupCapsuleDetailDto;
+import site.timecapsulearchive.core.domain.capsule.group_capsule.data.dto.GroupCapsuleSliceRequestDto;
 import site.timecapsulearchive.core.domain.capsule.group_capsule.data.dto.GroupCapsuleSummaryDto;
 import site.timecapsulearchive.core.domain.group.data.dto.GroupMemberSummaryDto;
 import site.timecapsulearchive.core.domain.member.entity.QMember;
@@ -176,5 +178,36 @@ public class GroupCapsuleQueryRepository {
             .from(capsule)
             .where(capsule.group.id.eq(groupId))
             .fetchOne();
+    }
+
+    public Slice<CapsuleBasicInfoDto> findGroupCapsuleSlice(final GroupCapsuleSliceRequestDto dto) {
+        final List<CapsuleBasicInfoDto> groupCapsuleDtos = jpaQueryFactory
+            .select(
+                Projections.constructor(
+                    CapsuleBasicInfoDto.class,
+                    capsule.id,
+                    capsuleSkin.imageUrl,
+                    capsule.dueDate,
+                    capsule.createdAt,
+                    capsule.title,
+                    capsule.isOpened,
+                    capsule.type
+                )
+            )
+            .from(capsule)
+            .where(capsule.group.id.eq(dto.groupId())
+                .and(capsuleIdPagingCursorCondition(dto.capsuleId())))
+            .limit(dto.size() + 1)
+            .fetch();
+
+        return SliceUtil.makeSlice(dto.size(), groupCapsuleDtos);
+    }
+
+    private BooleanExpression capsuleIdPagingCursorCondition(final Long capsuleId) {
+        if (capsuleId == null) {
+            return null;
+        }
+
+        return capsule.id.lt(capsuleId);
     }
 }

--- a/backend/core/src/main/java/site/timecapsulearchive/core/domain/capsule/group_capsule/service/GroupCapsuleService.java
+++ b/backend/core/src/main/java/site/timecapsulearchive/core/domain/capsule/group_capsule/service/GroupCapsuleService.java
@@ -14,6 +14,7 @@ import site.timecapsulearchive.core.domain.capsule.exception.CapsuleNotFondExcep
 import site.timecapsulearchive.core.domain.capsule.generic_capsule.repository.CapsuleRepository;
 import site.timecapsulearchive.core.domain.capsule.group_capsule.data.dto.GroupCapsuleCreateRequestDto;
 import site.timecapsulearchive.core.domain.capsule.group_capsule.data.dto.GroupCapsuleDetailDto;
+import site.timecapsulearchive.core.domain.capsule.group_capsule.data.dto.GroupCapsuleSliceRequestDto;
 import site.timecapsulearchive.core.domain.capsule.group_capsule.data.dto.GroupCapsuleSummaryDto;
 import site.timecapsulearchive.core.domain.capsule.group_capsule.data.dto.GroupCapsuleOpenStateDto;
 import site.timecapsulearchive.core.domain.capsule.group_capsule.repository.GroupCapsuleQueryRepository;
@@ -118,6 +119,10 @@ public class GroupCapsuleService {
 
         groupCapsule.open();
         return GroupCapsuleOpenStateDto.opened();
+    }
+
+    public Slice<CapsuleBasicInfoDto> findGroupCapsuleSlice(final GroupCapsuleSliceRequestDto dto) {
+        return groupCapsuleQueryRepository.findGroupCapsuleSlice(dto);
     }
 }
 

--- a/backend/core/src/main/java/site/timecapsulearchive/core/domain/capsule/group_capsule/service/GroupCapsuleService.java
+++ b/backend/core/src/main/java/site/timecapsulearchive/core/domain/capsule/group_capsule/service/GroupCapsuleService.java
@@ -21,6 +21,8 @@ import site.timecapsulearchive.core.domain.capsule.group_capsule.repository.Grou
 import site.timecapsulearchive.core.domain.capsuleskin.entity.CapsuleSkin;
 import site.timecapsulearchive.core.domain.group.entity.Group;
 import site.timecapsulearchive.core.domain.member.entity.Member;
+import site.timecapsulearchive.core.domain.member_group.exception.NoGroupAuthorityException;
+import site.timecapsulearchive.core.domain.member_group.repository.member_group_repository.MemberGroupRepository;
 
 @Service
 @Transactional(readOnly = true)
@@ -29,6 +31,7 @@ public class GroupCapsuleService {
 
     private final CapsuleRepository capsuleRepository;
     private final GroupCapsuleQueryRepository groupCapsuleQueryRepository;
+    private final MemberGroupRepository memberGroupRepository;
 
     @Transactional
     public Capsule saveGroupCapsule(
@@ -122,6 +125,12 @@ public class GroupCapsuleService {
     }
 
     public Slice<CapsuleBasicInfoDto> findGroupCapsuleSlice(final GroupCapsuleSliceRequestDto dto) {
+        boolean isGroupMember = memberGroupRepository.existMemberGroupByMemberIdAndGroupId(dto.memberId(),
+            dto.groupId());
+        if (!isGroupMember) {
+            throw new NoGroupAuthorityException();
+        }
+
         return groupCapsuleQueryRepository.findGroupCapsuleSlice(dto);
     }
 }

--- a/backend/core/src/main/java/site/timecapsulearchive/core/domain/member_group/repository/member_group_repository/MemberGroupQueryRepository.java
+++ b/backend/core/src/main/java/site/timecapsulearchive/core/domain/member_group/repository/member_group_repository/MemberGroupQueryRepository.java
@@ -20,4 +20,6 @@ public interface MemberGroupQueryRepository {
     Optional<Long> findGroupMembersCount(Long groupId);
 
     List<Long> findGroupMemberIdsByGroupId(final Long groupId);
+
+    boolean existMemberGroupByMemberIdAndGroupId(Long memberId, Long groupId);
 }

--- a/backend/core/src/main/java/site/timecapsulearchive/core/domain/member_group/repository/member_group_repository/MemberGroupQueryRepositoryImpl.java
+++ b/backend/core/src/main/java/site/timecapsulearchive/core/domain/member_group/repository/member_group_repository/MemberGroupQueryRepositoryImpl.java
@@ -110,4 +110,14 @@ public class MemberGroupQueryRepositoryImpl implements MemberGroupQueryRepositor
             .where(memberGroup.group.id.eq(groupId))
             .fetch();
     }
+
+    @Override
+    public boolean existMemberGroupByMemberIdAndGroupId(Long memberId, Long groupId) {
+        final Integer count = jpaQueryFactory.selectOne()
+            .from(memberGroup)
+            .where(memberGroup.member.id.eq(memberId).and(memberGroup.group.id.eq(groupId)))
+            .fetchFirst();
+
+        return count != null;
+    }
 }

--- a/backend/core/src/test/java/site/timecapsulearchive/core/common/fixture/domain/CapsuleFixture.java
+++ b/backend/core/src/test/java/site/timecapsulearchive/core/common/fixture/domain/CapsuleFixture.java
@@ -1,8 +1,8 @@
 package site.timecapsulearchive.core.common.fixture.domain;
 
 import java.lang.reflect.Field;
-import java.time.ZoneId;
 import java.time.ZonedDateTime;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.IntStream;
@@ -216,5 +216,19 @@ public class CapsuleFixture {
         setFieldValue(capsule, "isOpened", true);
 
         return Optional.ofNullable(capsule);
+    }
+
+    public static List<Capsule> groupCapsules(
+        Member owner,
+        CapsuleSkin capsuleSkin,
+        Group group,
+        int maxCount
+    ) {
+        List<Capsule> result = new ArrayList<>();
+        for (int count = 0; count < maxCount; count++) {
+            result.add(groupCapsule(owner, capsuleSkin, group));
+        }
+
+        return result;
     }
 }

--- a/backend/core/src/test/java/site/timecapsulearchive/core/common/fixture/dto/CapsuleBasicInfoDtoFixture.java
+++ b/backend/core/src/test/java/site/timecapsulearchive/core/common/fixture/dto/CapsuleBasicInfoDtoFixture.java
@@ -1,0 +1,21 @@
+package site.timecapsulearchive.core.common.fixture.dto;
+
+import java.time.ZonedDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import site.timecapsulearchive.core.domain.capsule.data.dto.CapsuleBasicInfoDto;
+import site.timecapsulearchive.core.domain.capsule.entity.CapsuleType;
+
+public class CapsuleBasicInfoDtoFixture {
+
+    public static List<CapsuleBasicInfoDto> capsuleBasicInfoDtos(Long capsuleId, int size) {
+        List<CapsuleBasicInfoDto> result = new ArrayList<>();
+        for (long count = capsuleId; count < size; count++) {
+            result.add(new CapsuleBasicInfoDto(count, count + "test-url", ZonedDateTime.now(),
+                ZonedDateTime.now(), count + "test-title", false, CapsuleType.GROUP));
+        }
+
+        return result;
+    }
+
+}

--- a/backend/core/src/test/java/site/timecapsulearchive/core/domain/capsule/group_capsule/repository/GroupCapsuleQueryRepositoryTest.java
+++ b/backend/core/src/test/java/site/timecapsulearchive/core/domain/capsule/group_capsule/repository/GroupCapsuleQueryRepositoryTest.java
@@ -1,13 +1,13 @@
 package site.timecapsulearchive.core.domain.capsule.group_capsule.repository;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
 
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import jakarta.persistence.EntityManager;
 import java.time.ZonedDateTime;
 import java.util.List;
 import java.util.Optional;
-import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -29,6 +29,7 @@ import site.timecapsulearchive.core.domain.capsule.entity.GroupCapsuleOpen;
 import site.timecapsulearchive.core.domain.capsule.generic_capsule.data.dto.CapsuleDetailDto;
 import site.timecapsulearchive.core.domain.capsule.generic_capsule.data.dto.CapsuleSummaryDto;
 import site.timecapsulearchive.core.domain.capsule.group_capsule.data.dto.GroupCapsuleDetailDto;
+import site.timecapsulearchive.core.domain.capsule.group_capsule.data.dto.GroupCapsuleSliceRequestDto;
 import site.timecapsulearchive.core.domain.capsule.group_capsule.data.dto.GroupCapsuleSummaryDto;
 import site.timecapsulearchive.core.domain.capsuleskin.entity.CapsuleSkin;
 import site.timecapsulearchive.core.domain.group.data.dto.GroupMemberSummaryDto;
@@ -39,10 +40,12 @@ import site.timecapsulearchive.core.domain.member_group.entity.MemberGroup;
 @TestConstructor(autowireMode = AutowireMode.ALL)
 class GroupCapsuleQueryRepositoryTest extends RepositoryTest {
 
+    private static final int MAX_COUNT = 20;
     private final GroupCapsuleQueryRepository groupCapsuleQueryRepository;
 
     private Long groupLeaderId;
-    private Long capsuleId;
+    private Long lastCapsuleId;
+    private Long groupId;
     private Capsule capsule;
 
     GroupCapsuleQueryRepositoryTest(JPAQueryFactory jpaQueryFactory) {
@@ -65,20 +68,24 @@ class GroupCapsuleQueryRepositoryTest extends RepositoryTest {
         //그룹
         Group group = GroupFixture.group();
         entityManager.persist(group);
+        groupId = group.getId();
 
         //그룹 구성
         List<MemberGroup> memberGroups = MemberGroupFixture.memberGroups(groupMember, group);
         memberGroups.forEach(entityManager::persist);
 
         //그룹 캡슐
-        capsule = CapsuleFixture.groupCapsule(owner, capsuleSkin, group);
-        entityManager.persist(capsule);
-        capsuleId = capsule.getId();
+        List<Capsule> capsules = CapsuleFixture.groupCapsules(owner, capsuleSkin, group, MAX_COUNT);
+        for (Capsule c : capsules) {
+            entityManager.persist(c);
 
-        //그룹 캡슐 오픈 여부
-        List<GroupCapsuleOpen> groupCapsuleOpens = GroupCapsuleOpenFixture.groupCapsuleOpens(false,
-            capsule, groupMember);
-        groupCapsuleOpens.forEach(entityManager::persist);
+            List<GroupCapsuleOpen> groupCapsuleOpens = GroupCapsuleOpenFixture.groupCapsuleOpens(
+                false,
+                c, groupMember);
+            groupCapsuleOpens.forEach(entityManager::persist);
+        }
+        capsule = capsules.get(0);
+        lastCapsuleId = capsules.get(capsules.size() - 1).getId();
     }
 
     @Test
@@ -86,11 +93,11 @@ class GroupCapsuleQueryRepositoryTest extends RepositoryTest {
         // given
         //when
         GroupCapsuleDetailDto groupCapsuleDetailDto = groupCapsuleQueryRepository.findGroupCapsuleDetailDtoByCapsuleId(
-            capsuleId).orElseThrow();
+            capsule.getId()).orElseThrow();
         CapsuleDetailDto capsuleDetailDto = groupCapsuleDetailDto.capsuleDetailDto();
 
         //then
-        SoftAssertions.assertSoftly(
+        assertSoftly(
             softly -> {
                 softly.assertThat(capsuleDetailDto).isNotNull();
                 softly.assertThat(capsuleDetailDto.capsuleType()).isEqualTo(capsule.getType());
@@ -106,11 +113,11 @@ class GroupCapsuleQueryRepositoryTest extends RepositoryTest {
         //given
         //when
         GroupCapsuleDetailDto detailDto = groupCapsuleQueryRepository.findGroupCapsuleDetailDtoByCapsuleId(
-            capsuleId).orElseThrow();
+            capsule.getId()).orElseThrow();
         List<GroupMemberSummaryDto> summaryDto = detailDto.members();
 
         //then
-        SoftAssertions.assertSoftly(
+        assertSoftly(
             softly -> {
                 softly.assertThat(summaryDto).isNotEmpty();
                 softly.assertThat(summaryDto).allMatch(dto -> !dto.isOpened());
@@ -137,11 +144,11 @@ class GroupCapsuleQueryRepositoryTest extends RepositoryTest {
         // given
         //when
         GroupCapsuleSummaryDto detailDto = groupCapsuleQueryRepository.findGroupCapsuleSummaryDtoByCapsuleId(
-            capsuleId).orElseThrow();
+            capsule.getId()).orElseThrow();
         CapsuleSummaryDto capsuleSummaryDto = detailDto.capsuleSummaryDto();
 
         //then
-        SoftAssertions.assertSoftly(
+        assertSoftly(
             softly -> {
                 softly.assertThat(capsuleSummaryDto).isNotNull();
                 softly.assertThat(capsuleSummaryDto.title()).isEqualTo(capsule.getTitle());
@@ -155,11 +162,11 @@ class GroupCapsuleQueryRepositoryTest extends RepositoryTest {
         // given
         //when
         GroupCapsuleSummaryDto detailDto = groupCapsuleQueryRepository.findGroupCapsuleSummaryDtoByCapsuleId(
-            capsuleId).orElseThrow();
+            capsule.getId()).orElseThrow();
         List<GroupMemberSummaryDto> summaryDto = detailDto.members();
 
         //then
-        SoftAssertions.assertSoftly(
+        assertSoftly(
             softly -> {
                 softly.assertThat(summaryDto).isNotEmpty();
                 softly.assertThat(summaryDto).allMatch(dto -> !dto.isOpened());
@@ -191,11 +198,60 @@ class GroupCapsuleQueryRepositoryTest extends RepositoryTest {
             groupLeaderId, size, now);
 
         //then
-        SoftAssertions.assertSoftly(softly -> {
+        assertSoftly(softly -> {
             assertThat(groupCapsules.hasContent()).isTrue();
             assertThat(groupCapsules).allMatch(
                 capsule -> capsule.capsuleType().equals(CapsuleType.GROUP));
             assertThat(groupCapsules).allMatch(capsule -> capsule.createdAt().isBefore(now));
         });
+    }
+
+    @Test
+    void 사용자가_그룹_캡슐_목록을_조회하면_해당_그룹의_그룹캡슐이_나온다() {
+        //then
+        int size = 20;
+        GroupCapsuleSliceRequestDto dto = GroupCapsuleSliceRequestDto.createOf(groupLeaderId,
+            groupId, size, lastCapsuleId);
+
+        //when
+        Slice<CapsuleBasicInfoDto> groupCapsuleSlice = groupCapsuleQueryRepository.findGroupCapsuleSlice(
+            dto);
+
+        //then
+        assertSoftly(softly -> {
+            softly.assertThat(groupCapsuleSlice.hasContent()).isTrue();
+            softly.assertThat(groupCapsuleSlice.getContent()).allMatch(c -> c.capsuleId() != null);
+            softly.assertThat(groupCapsuleSlice.getContent())
+                .allMatch(c -> c.capsuleType().equals(CapsuleType.GROUP));
+            softly.assertThat(groupCapsuleSlice.getContent()).allMatch(c -> c.isOpened() != null);
+            softly.assertThat(groupCapsuleSlice.getContent()).allMatch(c -> c.dueDate() != null);
+            softly.assertThat(groupCapsuleSlice.getContent()).allMatch(c -> c.createdAt() != null);
+            softly.assertThat(groupCapsuleSlice.getContent())
+                .allMatch(c -> c.skinUrl() != null && !c.skinUrl().isBlank());
+            softly.assertThat(groupCapsuleSlice.getContent())
+                .allMatch(c -> c.title() != null && !c.title().isBlank());
+        });
+    }
+
+    @Test
+    void 사용자가_그룹_캡슐_목록의_첫_페이지_이후_다음_페이지를_조회하면_다음_페이지의_그룹캡슐이_나온다() {
+        //then
+        int size = 10;
+        GroupCapsuleSliceRequestDto firstSliceDto = GroupCapsuleSliceRequestDto.createOf(
+            groupLeaderId,
+            groupId, size, null);
+        Slice<CapsuleBasicInfoDto> firstGroupCapsuleSlice = groupCapsuleQueryRepository.findGroupCapsuleSlice(
+            firstSliceDto);
+        CapsuleBasicInfoDto capsuleBasicInfoDto = firstGroupCapsuleSlice.getContent()
+            .get(0);
+
+        //when
+        GroupCapsuleSliceRequestDto dto = GroupCapsuleSliceRequestDto.createOf(groupLeaderId,
+            groupId, size, capsuleBasicInfoDto.capsuleId());
+        Slice<CapsuleBasicInfoDto> groupCapsuleSlice = groupCapsuleQueryRepository.findGroupCapsuleSlice(
+            dto);
+
+        //then
+        assertThat(groupCapsuleSlice.hasContent()).isTrue();
     }
 }

--- a/backend/core/src/test/java/site/timecapsulearchive/core/domain/capsule/group_capsule/repository/GroupCapsuleQueryRepositoryTest.java
+++ b/backend/core/src/test/java/site/timecapsulearchive/core/domain/capsule/group_capsule/repository/GroupCapsuleQueryRepositoryTest.java
@@ -22,6 +22,7 @@ import site.timecapsulearchive.core.common.fixture.domain.GroupCapsuleOpenFixtur
 import site.timecapsulearchive.core.common.fixture.domain.GroupFixture;
 import site.timecapsulearchive.core.common.fixture.domain.MemberFixture;
 import site.timecapsulearchive.core.common.fixture.domain.MemberGroupFixture;
+import site.timecapsulearchive.core.domain.capsule.data.dto.CapsuleBasicInfoDto;
 import site.timecapsulearchive.core.domain.capsule.entity.Capsule;
 import site.timecapsulearchive.core.domain.capsule.entity.CapsuleType;
 import site.timecapsulearchive.core.domain.capsule.entity.GroupCapsuleOpen;
@@ -29,7 +30,6 @@ import site.timecapsulearchive.core.domain.capsule.generic_capsule.data.dto.Caps
 import site.timecapsulearchive.core.domain.capsule.generic_capsule.data.dto.CapsuleSummaryDto;
 import site.timecapsulearchive.core.domain.capsule.group_capsule.data.dto.GroupCapsuleDetailDto;
 import site.timecapsulearchive.core.domain.capsule.group_capsule.data.dto.GroupCapsuleSummaryDto;
-import site.timecapsulearchive.core.domain.capsule.group_capsule.data.dto.MyGroupCapsuleDto;
 import site.timecapsulearchive.core.domain.capsuleskin.entity.CapsuleSkin;
 import site.timecapsulearchive.core.domain.group.data.dto.GroupMemberSummaryDto;
 import site.timecapsulearchive.core.domain.group.entity.Group;
@@ -187,7 +187,7 @@ class GroupCapsuleQueryRepositoryTest extends RepositoryTest {
         ZonedDateTime now = ZonedDateTime.now().plusDays(1);
 
         //when
-        Slice<MyGroupCapsuleDto> groupCapsules = groupCapsuleQueryRepository.findMyGroupCapsuleSlice(
+        Slice<CapsuleBasicInfoDto> groupCapsules = groupCapsuleQueryRepository.findMyGroupCapsuleSlice(
             groupLeaderId, size, now);
 
         //then

--- a/backend/core/src/test/java/site/timecapsulearchive/core/domain/capsule/group_capsule/service/GroupCapsuleServiceTest.java
+++ b/backend/core/src/test/java/site/timecapsulearchive/core/domain/capsule/group_capsule/service/GroupCapsuleServiceTest.java
@@ -1,7 +1,9 @@
 package site.timecapsulearchive.core.domain.capsule.group_capsule.service;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.SoftAssertions.assertSoftly;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
@@ -11,9 +13,13 @@ import java.time.ZonedDateTime;
 import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.Test;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.SliceImpl;
 import site.timecapsulearchive.core.common.fixture.domain.CapsuleFixture;
 import site.timecapsulearchive.core.common.fixture.domain.MemberFixture;
+import site.timecapsulearchive.core.common.fixture.dto.CapsuleBasicInfoDtoFixture;
 import site.timecapsulearchive.core.common.fixture.dto.CapsuleDtoFixture;
+import site.timecapsulearchive.core.domain.capsule.data.dto.CapsuleBasicInfoDto;
 import site.timecapsulearchive.core.domain.capsule.entity.Capsule;
 import site.timecapsulearchive.core.domain.capsule.exception.CapsuleNotFondException;
 import site.timecapsulearchive.core.domain.capsule.exception.GroupCapsuleOpenNotFoundException;
@@ -22,9 +28,12 @@ import site.timecapsulearchive.core.domain.capsule.generic_capsule.repository.Ca
 import site.timecapsulearchive.core.domain.capsule.group_capsule.data.dto.CapsuleOpenStatus;
 import site.timecapsulearchive.core.domain.capsule.group_capsule.data.dto.GroupCapsuleDetailDto;
 import site.timecapsulearchive.core.domain.capsule.group_capsule.data.dto.GroupCapsuleOpenStateDto;
+import site.timecapsulearchive.core.domain.capsule.group_capsule.data.dto.GroupCapsuleSliceRequestDto;
 import site.timecapsulearchive.core.domain.capsule.group_capsule.repository.GroupCapsuleQueryRepository;
 import site.timecapsulearchive.core.domain.group.data.dto.GroupMemberSummaryDto;
 import site.timecapsulearchive.core.domain.member.entity.Member;
+import site.timecapsulearchive.core.domain.member_group.exception.NoGroupAuthorityException;
+import site.timecapsulearchive.core.domain.member_group.repository.member_group_repository.MemberGroupRepository;
 import site.timecapsulearchive.core.global.error.ErrorCode;
 
 class GroupCapsuleServiceTest {
@@ -36,9 +45,10 @@ class GroupCapsuleServiceTest {
     private final CapsuleRepository capsuleRepository = mock(CapsuleRepository.class);
     private final GroupCapsuleQueryRepository groupCapsuleQueryRepository = mock(
         GroupCapsuleQueryRepository.class);
+    private final MemberGroupRepository memberGroupRepository = mock(MemberGroupRepository.class);
 
     private final GroupCapsuleService groupCapsuleService = new GroupCapsuleService(
-        capsuleRepository, groupCapsuleQueryRepository);
+        capsuleRepository, groupCapsuleQueryRepository, memberGroupRepository);
 
     @Test
     void 개봉된_그룹_캡슐의_상세_내용을_볼_수_있다() {
@@ -196,7 +206,8 @@ class GroupCapsuleServiceTest {
     @Test
     void 그룹_캡슐이_없는_경우_그룹_캡슐_개봉_시_예외가_발생한다() {
         //given
-        given(capsuleRepository.findNotOpenedGroupCapsuleByMemberIdAndCapsuleId(anyLong(), anyLong()))
+        given(
+            capsuleRepository.findNotOpenedGroupCapsuleByMemberIdAndCapsuleId(anyLong(), anyLong()))
             .willReturn(Optional.empty());
 
         //when
@@ -212,7 +223,8 @@ class GroupCapsuleServiceTest {
         ZonedDateTime now = ZonedDateTime.now(ZoneId.of("UTC"));
         Optional<Capsule> groupCapsule = CapsuleFixture.groupCapsuleSpecificTime(memberId,
             capsuleId, now.plusYears(5));
-        given(capsuleRepository.findNotOpenedGroupCapsuleByMemberIdAndCapsuleId(anyLong(), anyLong()))
+        given(
+            capsuleRepository.findNotOpenedGroupCapsuleByMemberIdAndCapsuleId(anyLong(), anyLong()))
             .willReturn(groupCapsule);
 
         //when
@@ -232,7 +244,8 @@ class GroupCapsuleServiceTest {
         //given
         Optional<Capsule> groupCapsule = CapsuleFixture.groupCapsuleSpecificTime(memberId,
             capsuleId, null);
-        given(capsuleRepository.findNotOpenedGroupCapsuleByMemberIdAndCapsuleId(anyLong(), anyLong()))
+        given(
+            capsuleRepository.findNotOpenedGroupCapsuleByMemberIdAndCapsuleId(anyLong(), anyLong()))
             .willReturn(groupCapsule);
 
         //when
@@ -254,7 +267,8 @@ class GroupCapsuleServiceTest {
         Optional<Capsule> groupCapsule = CapsuleFixture.groupCapsuleNotAllMemberOpen(memberId,
             capsuleId,
             groupMembers);
-        given(capsuleRepository.findNotOpenedGroupCapsuleByMemberIdAndCapsuleId(anyLong(), anyLong()))
+        given(
+            capsuleRepository.findNotOpenedGroupCapsuleByMemberIdAndCapsuleId(anyLong(), anyLong()))
             .willReturn(groupCapsule);
 
         //when
@@ -276,7 +290,8 @@ class GroupCapsuleServiceTest {
         Optional<Capsule> groupCapsule = CapsuleFixture.groupCapsuleHalfMemberOpen(memberId,
             capsuleId,
             groupMembers);
-        given(capsuleRepository.findNotOpenedGroupCapsuleByMemberIdAndCapsuleId(anyLong(), anyLong()))
+        given(
+            capsuleRepository.findNotOpenedGroupCapsuleByMemberIdAndCapsuleId(anyLong(), anyLong()))
             .willReturn(groupCapsule);
 
         //when
@@ -295,7 +310,8 @@ class GroupCapsuleServiceTest {
     void 그룹_캡슐_개봉이_없는_경우_예외가_발생한다() {
         //given
         Optional<Capsule> groupCapsule = CapsuleFixture.groupCapsuleEmptyOpen(memberId, capsuleId);
-        given(capsuleRepository.findNotOpenedGroupCapsuleByMemberIdAndCapsuleId(anyLong(), anyLong()))
+        given(
+            capsuleRepository.findNotOpenedGroupCapsuleByMemberIdAndCapsuleId(anyLong(), anyLong()))
             .willReturn(groupCapsule);
 
         //when
@@ -312,7 +328,8 @@ class GroupCapsuleServiceTest {
         Optional<Capsule> groupCapsule = CapsuleFixture.groupCapsuleAllMemberOpen(memberId,
             capsuleId,
             groupMembers);
-        given(capsuleRepository.findNotOpenedGroupCapsuleByMemberIdAndCapsuleId(anyLong(), anyLong()))
+        given(
+            capsuleRepository.findNotOpenedGroupCapsuleByMemberIdAndCapsuleId(anyLong(), anyLong()))
             .willReturn(groupCapsule);
 
         //when
@@ -334,7 +351,8 @@ class GroupCapsuleServiceTest {
         Optional<Capsule> groupCapsule = CapsuleFixture.groupCapsuleExcludeSpecificMember(memberId,
             capsuleId,
             groupMembers);
-        given(capsuleRepository.findNotOpenedGroupCapsuleByMemberIdAndCapsuleId(anyLong(), anyLong()))
+        given(
+            capsuleRepository.findNotOpenedGroupCapsuleByMemberIdAndCapsuleId(anyLong(), anyLong()))
             .willReturn(groupCapsule);
 
         //when
@@ -347,5 +365,44 @@ class GroupCapsuleServiceTest {
             softly.assertThat(groupCapsuleOpenStateDto.capsuleOpenStatus()).isEqualTo(
                 CapsuleOpenStatus.OPEN);
         });
+    }
+
+    @Test
+    void 사용자가_그룹원이_아니면_그룹_캡슐_목록_조회_시_예외가_발생한다() {
+        //given
+        Long groupId = 1L;
+        int size = 20;
+        GroupCapsuleSliceRequestDto dto = GroupCapsuleSliceRequestDto.createOf(memberId, groupId,
+            size, capsuleId);
+        given(memberGroupRepository.existMemberGroupByMemberIdAndGroupId(memberId, groupId))
+            .willReturn(false);
+
+        //when
+        //then
+        assertThatThrownBy(() -> groupCapsuleService.findGroupCapsuleSlice(dto))
+            .isInstanceOf(NoGroupAuthorityException.class)
+            .hasMessageContaining(ErrorCode.NO_GROUP_AUTHORITY_ERROR.getMessage());
+    }
+
+    @Test
+    void 사용자가_그룹원이면_그룹_캡슐_목록_조회_시_그룹_캡슐_목록이_조회된다() {
+        //given
+        Long groupId = 1L;
+        int size = 20;
+        GroupCapsuleSliceRequestDto dto = GroupCapsuleSliceRequestDto.createOf(memberId, groupId,
+            size, capsuleId);
+        given(memberGroupRepository.existMemberGroupByMemberIdAndGroupId(memberId, groupId))
+            .willReturn(true);
+        given(groupCapsuleQueryRepository.findGroupCapsuleSlice(
+            any(GroupCapsuleSliceRequestDto.class)))
+            .willReturn(
+                new SliceImpl<>(CapsuleBasicInfoDtoFixture.capsuleBasicInfoDtos(capsuleId, size)));
+
+        //when
+        Slice<CapsuleBasicInfoDto> groupCapsuleSlice = groupCapsuleService.findGroupCapsuleSlice(
+            dto);
+
+        //then
+        assertThat(groupCapsuleSlice.hasContent()).isTrue();
     }
 }


### PR DESCRIPTION
## 작업 내용 (Content)
- 그룹 캡슐 목록 조회 기능 추가
- 테스트 추가

## 링크 (Links)
- #476 

## 기타 사항 (Etc)
1. 그전에 쿼리로 그룹원 여부 확인 및 검증
![Screenshot from 2024-06-08 21-00-36](https://github.com/tukcomCD2024/DroidBlossom/assets/68144059/32332075-771c-447a-8171-9afe8e7b661a)
2. join + where로 검증
![Screenshot from 2024-06-08 21-04-02](https://github.com/tukcomCD2024/DroidBlossom/assets/68144059/254597b2-5a1d-4f25-a70c-cede1595dc18)

- 그룹에 대한 정보를 조회할 때 그전에 그룹원인지 검증하고 싶은데 뭐가 더 좋을지 모르겠음. 
1은 한방 쿼리로 해결할 수 있긴하나 그룹원이 아닌데 그룹 정보를 조회하는 API에서 그룹원이 아닌데 조회가 된다는 것이 약간 논리적으로 이상하긴함

현재는 1번을 택해서 구현했음.

## Merge 전 필요 작업 (Checklist before merge)

## 희망 리뷰 완료 일 (Expected due date)
