### PR TITLE
fix : 그룹 캡슐 개봉 로직 수정 #483

### DIFF
--- a/backend/core/src/main/java/site/timecapsulearchive/core/domain/capsule/group_capsule/data/dto/GroupCapsuleOpenStateDto.java
+++ b/backend/core/src/main/java/site/timecapsulearchive/core/domain/capsule/group_capsule/data/dto/GroupCapsuleOpenStateDto.java
@@ -3,21 +3,23 @@ package site.timecapsulearchive.core.domain.capsule.group_capsule.data.dto;
 import site.timecapsulearchive.core.domain.capsule.group_capsule.data.response.GroupCapsuleOpenStateResponse;
 
 public record GroupCapsuleOpenStateDto(
-    CapsuleOpenStatus capsuleOpenStatus
+    CapsuleOpenStatus capsuleOpenStatus,
+    boolean isIndividuallyOpened
 ) {
 
     public static GroupCapsuleOpenStateDto opened() {
-        return new GroupCapsuleOpenStateDto(CapsuleOpenStatus.OPEN);
+        return new GroupCapsuleOpenStateDto(CapsuleOpenStatus.OPEN, true);
     }
 
-    public static GroupCapsuleOpenStateDto notOpened() {
-        return new GroupCapsuleOpenStateDto(CapsuleOpenStatus.NOT_OPEN);
+    public static GroupCapsuleOpenStateDto notOpened(boolean isIndividuallyOpened) {
+        return new GroupCapsuleOpenStateDto(CapsuleOpenStatus.NOT_OPEN, isIndividuallyOpened);
     }
 
     public GroupCapsuleOpenStateResponse toResponse() {
         return new GroupCapsuleOpenStateResponse(
             capsuleOpenStatus,
-            capsuleOpenStatus.getStatusMessage()
+            capsuleOpenStatus.getStatusMessage(),
+            isIndividuallyOpened
         );
     }
 }

--- a/backend/core/src/main/java/site/timecapsulearchive/core/domain/capsule/group_capsule/data/response/GroupCapsuleOpenStateResponse.java
+++ b/backend/core/src/main/java/site/timecapsulearchive/core/domain/capsule/group_capsule/data/response/GroupCapsuleOpenStateResponse.java
@@ -1,10 +1,19 @@
 package site.timecapsulearchive.core.domain.capsule.group_capsule.data.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import site.timecapsulearchive.core.domain.capsule.group_capsule.data.dto.CapsuleOpenStatus;
 
+@Schema(description = "그룹 캡슐 개봉 상태 응답")
 public record GroupCapsuleOpenStateResponse(
+
+    @Schema(description = "캡슐 개봉 상태")
     CapsuleOpenStatus capsuleOpenStatus,
-    String statusMessage
+
+    @Schema(description = "캡슐 개봉 상태 메시지")
+    String statusMessage,
+
+    @Schema(description = "현재 요청한 사용자의 개별적인 캡슐 개봉 상태")
+    boolean isIndividuallyOpened
 ) {
 
 }

--- a/backend/core/src/main/java/site/timecapsulearchive/core/domain/capsule/group_capsule/service/GroupCapsuleService.java
+++ b/backend/core/src/main/java/site/timecapsulearchive/core/domain/capsule/group_capsule/service/GroupCapsuleService.java
@@ -102,18 +102,18 @@ public class GroupCapsuleService {
                 capsuleId)
             .orElseThrow(CapsuleNotFondException::new);
 
-        if (!groupCapsule.canOpen()) {
-            return GroupCapsuleOpenStateDto.notOpened();
+        if (groupCapsule.isNotCapsuleOpened()) {
+            return GroupCapsuleOpenStateDto.notOpened(false);
         }
 
-        if (!groupCapsule.isTimeCapsule()) {
+        if (groupCapsule.isNotTimeCapsule()) {
             groupCapsule.open();
             return GroupCapsuleOpenStateDto.opened();
         }
 
         boolean allGroupMemberOpened = groupCapsule.isAllGroupMemberOpened(memberId, capsuleId);
         if (!allGroupMemberOpened) {
-            return GroupCapsuleOpenStateDto.notOpened();
+            return GroupCapsuleOpenStateDto.notOpened(true);
         }
 
         groupCapsule.open();

--- a/backend/core/src/test/java/site/timecapsulearchive/core/domain/capsule/group_capsule/service/GroupCapsuleServiceTest.java
+++ b/backend/core/src/test/java/site/timecapsulearchive/core/domain/capsule/group_capsule/service/GroupCapsuleServiceTest.java
@@ -224,6 +224,7 @@ class GroupCapsuleServiceTest {
             softly.assertThat(groupCapsule.get().getIsOpened()).isFalse();
             softly.assertThat(groupCapsuleOpenStateDto.capsuleOpenStatus())
                 .isEqualTo(CapsuleOpenStatus.NOT_OPEN);
+            softly.assertThat(groupCapsuleOpenStateDto.isIndividuallyOpened()).isFalse();
         });
     }
 
@@ -244,6 +245,7 @@ class GroupCapsuleServiceTest {
             softly.assertThat(groupCapsule.get().getIsOpened()).isTrue();
             softly.assertThat(groupCapsuleOpenStateDto.capsuleOpenStatus())
                 .isEqualTo(CapsuleOpenStatus.OPEN);
+            softly.assertThat(groupCapsuleOpenStateDto.isIndividuallyOpened()).isTrue();
         });
     }
 
@@ -266,6 +268,7 @@ class GroupCapsuleServiceTest {
             softly.assertThat(groupCapsule.get().getIsOpened()).isFalse();
             softly.assertThat(groupCapsuleOpenStateDto.capsuleOpenStatus()).isEqualTo(
                 CapsuleOpenStatus.NOT_OPEN);
+            softly.assertThat(groupCapsuleOpenStateDto.isIndividuallyOpened()).isTrue();
         });
     }
 
@@ -288,6 +291,7 @@ class GroupCapsuleServiceTest {
             softly.assertThat(groupCapsule.get().getIsOpened()).isFalse();
             softly.assertThat(groupCapsuleOpenStateDto.capsuleOpenStatus()).isEqualTo(
                 CapsuleOpenStatus.NOT_OPEN);
+            softly.assertThat(groupCapsuleOpenStateDto.isIndividuallyOpened()).isTrue();
         });
     }
 
@@ -324,6 +328,7 @@ class GroupCapsuleServiceTest {
             softly.assertThat(groupCapsule.get().getIsOpened()).isTrue();
             softly.assertThat(groupCapsuleOpenStateDto.capsuleOpenStatus()).isEqualTo(
                 CapsuleOpenStatus.OPEN);
+            softly.assertThat(groupCapsuleOpenStateDto.isIndividuallyOpened()).isTrue();
         });
     }
 
@@ -346,6 +351,7 @@ class GroupCapsuleServiceTest {
             softly.assertThat(groupCapsule.get().getIsOpened()).isTrue();
             softly.assertThat(groupCapsuleOpenStateDto.capsuleOpenStatus()).isEqualTo(
                 CapsuleOpenStatus.OPEN);
+            softly.assertThat(groupCapsuleOpenStateDto.isIndividuallyOpened()).isTrue();
         });
     }
 }


### PR DESCRIPTION
## 작업 내용 (Content)
- 그룹 캡슐 개봉 로직 수정(조건식을 ! + 긍정문을 부정문으로)
- 개별 개봉 상태 추가

## 링크 (Links)
- #483 

## 기타 사항 (Etc)
- 개별 상태가 없어서 개별적으론 열어도 캡슐이 안열렸다고 내려가니 프론트에서 개별적으로 개봉된건지 캡슐이 개봉된건지 인지 불가능

## Merge 전 필요 작업 (Checklist before merge)

## 희망 리뷰 완료 일 (Expected due date)
