### PR TITLE
fix : 그룹 캡슐 API 수정

### DIFF
--- a/backend/core/src/main/java/site/timecapsulearchive/core/domain/capsule/group_capsule/api/GroupCapsuleApi.java
+++ b/backend/core/src/main/java/site/timecapsulearchive/core/domain/capsule/group_capsule/api/GroupCapsuleApi.java
@@ -98,9 +98,6 @@ public interface GroupCapsuleApi {
     ResponseEntity<ApiSpec<GroupCapsuleSummaryResponse>> getGroupCapsuleSummaryByCapsuleId(
         Long memberId,
 
-        @Parameter(in = ParameterIn.QUERY, description = "그룹 아이디", required = true)
-        Long groupId,
-
         @Parameter(in = ParameterIn.PATH, description = "조회할 캡슐 아이디", required = true)
         Long capsuleId
     );

--- a/backend/core/src/main/java/site/timecapsulearchive/core/domain/capsule/group_capsule/api/GroupCapsuleApiController.java
+++ b/backend/core/src/main/java/site/timecapsulearchive/core/domain/capsule/group_capsule/api/GroupCapsuleApiController.java
@@ -95,12 +95,10 @@ public class GroupCapsuleApiController implements GroupCapsuleApi {
     @Override
     public ResponseEntity<ApiSpec<GroupCapsuleSummaryResponse>> getGroupCapsuleSummaryByCapsuleId(
         @AuthenticationPrincipal Long memberId,
-        @RequestParam("group_id") Long groupId,
         @PathVariable("capsule_id") Long capsuleId
     ) {
         CombinedGroupCapsuleSummaryDto groupCapsuleSummary = groupCapsuleService.findGroupCapsuleSummary(
             memberId,
-            groupId,
             capsuleId
         );
 

--- a/backend/core/src/main/java/site/timecapsulearchive/core/domain/capsule/group_capsule/repository/GroupCapsuleQueryRepository.java
+++ b/backend/core/src/main/java/site/timecapsulearchive/core/domain/capsule/group_capsule/repository/GroupCapsuleQueryRepository.java
@@ -91,7 +91,6 @@ public class GroupCapsuleQueryRepository {
     }
 
     public Optional<GroupCapsuleSummaryDto> findGroupCapsuleSummaryDtoByCapsuleId(
-        final Long groupId,
         final Long capsuleId
     ) {
         return Optional.ofNullable(
@@ -120,7 +119,6 @@ public class GroupCapsuleQueryRepository {
                 .join(capsule.capsuleSkin, capsuleSkin)
                 .join(capsule.group, group)
                 .where(capsule.id.eq(capsuleId)
-                    .and(capsule.group.id.eq(groupId))
                     .and(capsule.type.eq(CapsuleType.GROUP))
                 )
                 .fetchOne()

--- a/backend/core/src/main/java/site/timecapsulearchive/core/domain/capsule/group_capsule/service/GroupCapsuleService.java
+++ b/backend/core/src/main/java/site/timecapsulearchive/core/domain/capsule/group_capsule/service/GroupCapsuleService.java
@@ -82,27 +82,24 @@ public class GroupCapsuleService {
      * 그룹 캡슐의 요약 정보를 조회한다.
      * <br>
      * @param memberId 사용자 아이디
-     * @param groupId 캡슐이 만들어진 그룹 아이디
      * @param capsuleId 조회할 캡슐 아이디
      * @return 그룹 캡슐의 요약 정보(캡슐, 그룹원)
      * @throws NoGroupAuthorityException 그룹에 대한 권한이 존재하지 않으면 예외가 발생한다.
      */
     public CombinedGroupCapsuleSummaryDto findGroupCapsuleSummary(
         final Long memberId,
-        final Long groupId,
         final Long capsuleId
     ) {
+        GroupCapsuleSummaryDto groupCapsuleSummaryDto = groupCapsuleQueryRepository.findGroupCapsuleSummaryDtoByCapsuleId(capsuleId)
+            .orElseThrow(CapsuleNotFondException::new);
+
         List<GroupCapsuleMemberDto> groupCapsuleMembers = memberGroupRepository.findGroupCapsuleMembers(
-            groupId, capsuleId);
+            groupCapsuleSummaryDto.groupId(), capsuleId);
 
         GroupCapsuleMemberDto requestMember = groupCapsuleMembers.stream()
             .filter(dto -> memberId.equals(dto.id()))
             .findAny()
             .orElseThrow(NoGroupAuthorityException::new);
-
-        GroupCapsuleSummaryDto groupCapsuleSummaryDto = groupCapsuleQueryRepository.findGroupCapsuleSummaryDtoByCapsuleId(
-            groupId, capsuleId)
-            .orElseThrow(CapsuleNotFondException::new);
 
         Boolean hasEditPermission = requestMember.id().equals(groupCapsuleSummaryDto.creatorId());
         Boolean hasDeletePermission = hasEditPermission || requestMember.isGroupOwner();

--- a/backend/core/src/test/java/site/timecapsulearchive/core/domain/capsule/group_capsule/repository/GroupCapsuleQueryRepositoryTest.java
+++ b/backend/core/src/test/java/site/timecapsulearchive/core/domain/capsule/group_capsule/repository/GroupCapsuleQueryRepositoryTest.java
@@ -145,7 +145,7 @@ class GroupCapsuleQueryRepositoryTest extends RepositoryTest {
         // given
         //when
         GroupCapsuleSummaryDto capsuleSummaryDto = groupCapsuleQueryRepository.findGroupCapsuleSummaryDtoByCapsuleId(
-            groupId, capsule.getId()).orElseThrow();
+            capsule.getId()).orElseThrow();
 
         //then
         assertSoftly(
@@ -165,7 +165,7 @@ class GroupCapsuleQueryRepositoryTest extends RepositoryTest {
 
         //when
         Optional<GroupCapsuleSummaryDto> detailDto = groupCapsuleQueryRepository.findGroupCapsuleSummaryDtoByCapsuleId(
-            notCapsuleId, groupId);
+            notCapsuleId);
         //then
         assertThat(detailDto).isEmpty();
     }

--- a/backend/core/src/test/java/site/timecapsulearchive/core/domain/capsule/group_capsule/service/GroupCapsuleServiceTest.java
+++ b/backend/core/src/test/java/site/timecapsulearchive/core/domain/capsule/group_capsule/service/GroupCapsuleServiceTest.java
@@ -460,31 +460,30 @@ class GroupCapsuleServiceTest {
         //given
         Long groupId = 1L;
         Long notGroupMemberId = 999L;
+        given(groupCapsuleQueryRepository.findGroupCapsuleSummaryDtoByCapsuleId(capsuleId))
+            .willReturn(Optional.of(
+                GroupCapsuleSummaryDtoFixture.groupCapsule(groupId, memberId)));
         given(memberGroupRepository.findGroupCapsuleMembers(anyLong(), anyLong()))
             .willReturn(GroupCapsuleMemberDtoFixture.members(0, 10, false));
 
         //when
         //then
         assertThatThrownBy(
-            () -> groupCapsuleService.findGroupCapsuleSummary(notGroupMemberId, groupId, capsuleId))
+            () -> groupCapsuleService.findGroupCapsuleSummary(notGroupMemberId, capsuleId))
             .isInstanceOf(NoGroupAuthorityException.class)
             .hasMessageContaining(ErrorCode.NO_GROUP_AUTHORITY_ERROR.getMessage());
     }
 
     @Test
-    void 그룹원이_없는_그룹_캡슐을_요약_조회_시_예외가_발생한다() {
+    void 그룹원이_존재하지_않는_그룹_캡슐을_요약_조회_시_예외가_발생한다() {
         //given
-        Long groupId = 1L;
-
-        given(memberGroupRepository.findGroupCapsuleMembers(anyLong(), anyLong()))
-            .willReturn(GroupCapsuleMemberDtoFixture.members(0, 10, false));
-        given(groupCapsuleQueryRepository.findGroupCapsuleSummaryDtoByCapsuleId(groupId, capsuleId))
+        given(groupCapsuleQueryRepository.findGroupCapsuleSummaryDtoByCapsuleId(capsuleId))
             .willReturn(Optional.empty());
 
         //when
         //then
         assertThatThrownBy(
-            () -> groupCapsuleService.findGroupCapsuleSummary(memberId, groupId, capsuleId))
+            () -> groupCapsuleService.findGroupCapsuleSummary(memberId, capsuleId))
             .isInstanceOf(CapsuleNotFondException.class)
             .hasMessageContaining(ErrorCode.CAPSULE_NOT_FOUND_ERROR.getMessage());
     }
@@ -496,13 +495,13 @@ class GroupCapsuleServiceTest {
 
         given(memberGroupRepository.findGroupCapsuleMembers(anyLong(), anyLong()))
             .willReturn(GroupCapsuleMemberDtoFixture.members(0, 10, false));
-        given(groupCapsuleQueryRepository.findGroupCapsuleSummaryDtoByCapsuleId(groupId, capsuleId))
+        given(groupCapsuleQueryRepository.findGroupCapsuleSummaryDtoByCapsuleId(capsuleId))
             .willReturn(Optional.of(
                 GroupCapsuleSummaryDtoFixture.groupCapsule(groupId, memberId)));
 
         //when
         CombinedGroupCapsuleSummaryDto groupCapsuleSummaryDto = groupCapsuleService.findGroupCapsuleSummary(
-            memberId, groupId, capsuleId);;
+            memberId, capsuleId);;
 
         //then
         assertThat(groupCapsuleSummaryDto).isNotNull();
@@ -516,13 +515,13 @@ class GroupCapsuleServiceTest {
 
         given(memberGroupRepository.findGroupCapsuleMembers(anyLong(), anyLong()))
             .willReturn(GroupCapsuleMemberDtoFixture.members(1, 10, false));
-        given(groupCapsuleQueryRepository.findGroupCapsuleSummaryDtoByCapsuleId(groupId, capsuleId))
+        given(groupCapsuleQueryRepository.findGroupCapsuleSummaryDtoByCapsuleId(capsuleId))
             .willReturn(Optional.of(
                 GroupCapsuleSummaryDtoFixture.groupCapsule(groupId, memberId)));
 
         //when
         CombinedGroupCapsuleSummaryDto groupCapsuleSummaryDto = groupCapsuleService.findGroupCapsuleSummary(
-            groupMemberId, groupId, capsuleId);;
+            groupMemberId, capsuleId);;
 
         //then
         assertThat(groupCapsuleSummaryDto.hasEditPermission()).isFalse();
@@ -536,13 +535,13 @@ class GroupCapsuleServiceTest {
 
         given(memberGroupRepository.findGroupCapsuleMembers(anyLong(), anyLong()))
             .willReturn(GroupCapsuleMemberDtoFixture.members(1, 10, false));
-        given(groupCapsuleQueryRepository.findGroupCapsuleSummaryDtoByCapsuleId(groupId, capsuleId))
+        given(groupCapsuleQueryRepository.findGroupCapsuleSummaryDtoByCapsuleId(capsuleId))
             .willReturn(Optional.of(
                 GroupCapsuleSummaryDtoFixture.groupCapsule(groupId, memberId)));
 
         //when
         CombinedGroupCapsuleSummaryDto groupCapsuleSummaryDto = groupCapsuleService.findGroupCapsuleSummary(
-            groupMemberId, groupId, capsuleId);;
+            groupMemberId, capsuleId);;
 
         //then
         assertThat(groupCapsuleSummaryDto.hasDeletePermission()).isFalse();
@@ -555,13 +554,13 @@ class GroupCapsuleServiceTest {
 
         given(memberGroupRepository.findGroupCapsuleMembers(anyLong(), anyLong()))
             .willReturn(GroupCapsuleMemberDtoFixture.members(1, 10, false));
-        given(groupCapsuleQueryRepository.findGroupCapsuleSummaryDtoByCapsuleId(groupId, capsuleId))
+        given(groupCapsuleQueryRepository.findGroupCapsuleSummaryDtoByCapsuleId(capsuleId))
             .willReturn(Optional.of(
                 GroupCapsuleSummaryDtoFixture.groupCapsule(groupId, memberId)));
 
         //when
         CombinedGroupCapsuleSummaryDto groupCapsuleSummaryDto = groupCapsuleService.findGroupCapsuleSummary(
-            memberId, groupId, capsuleId);;
+            memberId, capsuleId);;
 
         //then
         assertThat(groupCapsuleSummaryDto.hasEditPermission()).isTrue();
@@ -574,13 +573,13 @@ class GroupCapsuleServiceTest {
 
         given(memberGroupRepository.findGroupCapsuleMembers(anyLong(), anyLong()))
             .willReturn(GroupCapsuleMemberDtoFixture.members(1, 10, false));
-        given(groupCapsuleQueryRepository.findGroupCapsuleSummaryDtoByCapsuleId(groupId, capsuleId))
+        given(groupCapsuleQueryRepository.findGroupCapsuleSummaryDtoByCapsuleId(capsuleId))
             .willReturn(Optional.of(
                 GroupCapsuleSummaryDtoFixture.groupCapsule(groupId, memberId)));
 
         //when
         CombinedGroupCapsuleSummaryDto groupCapsuleSummaryDto = groupCapsuleService.findGroupCapsuleSummary(
-            memberId, groupId, capsuleId);;
+            memberId, capsuleId);;
 
         //then
         assertThat(groupCapsuleSummaryDto.hasDeletePermission()).isTrue();
@@ -593,13 +592,13 @@ class GroupCapsuleServiceTest {
 
         given(memberGroupRepository.findGroupCapsuleMembers(anyLong(), anyLong()))
             .willReturn(GroupCapsuleMemberDtoFixture.members(1, 10, true));
-        given(groupCapsuleQueryRepository.findGroupCapsuleSummaryDtoByCapsuleId(groupId, capsuleId))
+        given(groupCapsuleQueryRepository.findGroupCapsuleSummaryDtoByCapsuleId(capsuleId))
             .willReturn(Optional.of(
                 GroupCapsuleSummaryDtoFixture.groupCapsule(groupId, memberId)));
 
         //when
         CombinedGroupCapsuleSummaryDto groupCapsuleSummaryDto = groupCapsuleService.findGroupCapsuleSummary(
-            memberId, groupId, capsuleId);;
+            memberId, capsuleId);;
 
         //then
         assertThat(groupCapsuleSummaryDto.isRequestMemberCapsuleOpen()).isTrue();
@@ -612,13 +611,13 @@ class GroupCapsuleServiceTest {
 
         given(memberGroupRepository.findGroupCapsuleMembers(anyLong(), anyLong()))
             .willReturn(GroupCapsuleMemberDtoFixture.members(1, 10, false));
-        given(groupCapsuleQueryRepository.findGroupCapsuleSummaryDtoByCapsuleId(groupId, capsuleId))
+        given(groupCapsuleQueryRepository.findGroupCapsuleSummaryDtoByCapsuleId(capsuleId))
             .willReturn(Optional.of(
                 GroupCapsuleSummaryDtoFixture.groupCapsule(groupId, memberId)));
 
         //when
         CombinedGroupCapsuleSummaryDto groupCapsuleSummaryDto = groupCapsuleService.findGroupCapsuleSummary(
-            memberId, groupId, capsuleId);;
+            memberId, capsuleId);;
 
         //then
         assertThat(groupCapsuleSummaryDto.isRequestMemberCapsuleOpen()).isFalse();


### PR DESCRIPTION
## 작업 내용 (Content)
- 그룹 아이디 안 받게 수정

## 링크 (Links)
- #490 

## 기타 사항 (Etc)
- 조회 순서만 변경
- 추후 그룹 아이디 받도록 하던지 그룹원을 빼와서 검증하던지 해야할 듯

## Merge 전 필요 작업 (Checklist before merge)

## 희망 리뷰 완료 일 (Expected due date)
