### PR TITLE
fix : 보물 캡슐 중복 수령 시 필터링 #534

### DIFF
--- a/backend/core/src/main/java/site/timecapsulearchive/core/domain/capsule/treasure_capsule/api/TreasureCapsuleController.java
+++ b/backend/core/src/main/java/site/timecapsulearchive/core/domain/capsule/treasure_capsule/api/TreasureCapsuleController.java
@@ -37,10 +37,7 @@ public class TreasureCapsuleController implements TreasureCapsuleApi {
         return ResponseEntity.accepted().body(
             ApiSpec.success(
                 SuccessCode.SUCCESS,
-                TreasureCapsuleOpenResponse.createOf(
-                    treasureCapsuleOpenDto,
-                    s3PreSignedUrlManager::getS3PreSignedUrlForGet
-                )
+                treasureCapsuleOpenDto.toResponse(s3PreSignedUrlManager::getS3PreSignedUrlForGet)
             )
         );
     }

--- a/backend/core/src/main/java/site/timecapsulearchive/core/domain/capsule/treasure_capsule/data/dto/TreasureCapsuleOpenDto.java
+++ b/backend/core/src/main/java/site/timecapsulearchive/core/domain/capsule/treasure_capsule/data/dto/TreasureCapsuleOpenDto.java
@@ -1,15 +1,17 @@
 package site.timecapsulearchive.core.domain.capsule.treasure_capsule.data.dto;
 
-import java.util.function.Function;
+import java.util.function.UnaryOperator;
 import site.timecapsulearchive.core.domain.capsule.treasure_capsule.data.response.TreasureCapsuleOpenResponse;
 
 public record TreasureCapsuleOpenDto(
+    TreasureOpenStatus treasureOpenStatus,
     String treasureImageUrl
 ) {
 
-    public TreasureCapsuleOpenResponse toResponse(final Function<String, String> s3PreSignedUrlForGet) {
+    public TreasureCapsuleOpenResponse toResponse(
+        final UnaryOperator<String> s3PreSignedUrlForGet) {
         String imageUrl = s3PreSignedUrlForGet.apply(treasureImageUrl);
-        
-        return new TreasureCapsuleOpenResponse(imageUrl);
+
+        return new TreasureCapsuleOpenResponse(treasureOpenStatus, imageUrl);
     }
 }

--- a/backend/core/src/main/java/site/timecapsulearchive/core/domain/capsule/treasure_capsule/data/dto/TreasureCapsuleOpenDto.java
+++ b/backend/core/src/main/java/site/timecapsulearchive/core/domain/capsule/treasure_capsule/data/dto/TreasureCapsuleOpenDto.java
@@ -9,6 +9,7 @@ public record TreasureCapsuleOpenDto(
 
     public TreasureCapsuleOpenResponse toResponse(final Function<String, String> s3PreSignedUrlForGet) {
         String imageUrl = s3PreSignedUrlForGet.apply(treasureImageUrl);
+        
         return new TreasureCapsuleOpenResponse(imageUrl);
     }
 }

--- a/backend/core/src/main/java/site/timecapsulearchive/core/domain/capsule/treasure_capsule/data/dto/TreasureOpenStatus.java
+++ b/backend/core/src/main/java/site/timecapsulearchive/core/domain/capsule/treasure_capsule/data/dto/TreasureOpenStatus.java
@@ -1,0 +1,5 @@
+package site.timecapsulearchive.core.domain.capsule.treasure_capsule.data.dto;
+
+public enum TreasureOpenStatus {
+    SUCCESS, DUPLICATE
+}

--- a/backend/core/src/main/java/site/timecapsulearchive/core/domain/capsule/treasure_capsule/data/response/TreasureCapsuleOpenResponse.java
+++ b/backend/core/src/main/java/site/timecapsulearchive/core/domain/capsule/treasure_capsule/data/response/TreasureCapsuleOpenResponse.java
@@ -1,20 +1,15 @@
 package site.timecapsulearchive.core.domain.capsule.treasure_capsule.data.response;
 
 import io.swagger.v3.oas.annotations.media.Schema;
-import java.util.function.Function;
-import site.timecapsulearchive.core.domain.capsule.treasure_capsule.data.dto.TreasureCapsuleOpenDto;
+import site.timecapsulearchive.core.domain.capsule.treasure_capsule.data.dto.TreasureOpenStatus;
 
 @Schema(name = "보물 캡슐 개봉 응답")
 public record TreasureCapsuleOpenResponse(
+    @Schema(name = "보물 개봉 상태")
+    TreasureOpenStatus treasureOpenStatus,
+
     @Schema(name = "보물 이미지 URL")
     String treasureImageUrl
 ) {
-
-    public static TreasureCapsuleOpenResponse createOf(
-        final TreasureCapsuleOpenDto dto,
-        final Function<String, String> s3PreSignedUrlForGet
-    ) {
-        return dto.toResponse(s3PreSignedUrlForGet);
-    }
 
 }

--- a/backend/core/src/main/java/site/timecapsulearchive/core/domain/capsule/treasure_capsule/service/TreasureCapsuleService.java
+++ b/backend/core/src/main/java/site/timecapsulearchive/core/domain/capsule/treasure_capsule/service/TreasureCapsuleService.java
@@ -30,7 +30,6 @@ public class TreasureCapsuleService {
             MemberNotFoundException::new);
 
         String treasureImageUrl = transactionTemplate.execute(status -> {
-            // 이미지와 함께 캡슐 조회
             final Capsule treasureCapsule = capsuleRepository.findCapsuleWithImageByCapsuleId(
                 capsuleId).orElseThrow(CapsuleNotFondException::new);
 
@@ -38,7 +37,12 @@ public class TreasureCapsuleService {
             final String imageUrl = image.getImageUrl();
             capsuleRepository.delete(treasureCapsule);
 
-            // caspuleSkin 저장
+            final boolean isAlreadyGetTreasure = capsuleSkinRepository.existByImageUrlAndMemberId(
+                imageUrl, member.getId());
+            if (isAlreadyGetTreasure) {
+                return imageUrl;
+            }
+
             final CapsuleSkin myTreasureCapsuleSkin = CapsuleSkin.captureTreasureCapsuleSkin(
                 imageUrl, member);
             capsuleSkinRepository.save(myTreasureCapsuleSkin);

--- a/backend/core/src/main/java/site/timecapsulearchive/core/domain/capsuleskin/repository/CapsuleSkinQueryRepository.java
+++ b/backend/core/src/main/java/site/timecapsulearchive/core/domain/capsuleskin/repository/CapsuleSkinQueryRepository.java
@@ -1,69 +1,14 @@
 package site.timecapsulearchive.core.domain.capsuleskin.repository;
 
-import static site.timecapsulearchive.core.domain.capsuleskin.entity.QCapsuleSkin.capsuleSkin;
-
-import com.querydsl.core.types.Projections;
-import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.time.ZonedDateTime;
-import java.util.List;
-import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
-import org.springframework.data.domain.SliceImpl;
-import org.springframework.stereotype.Repository;
 import site.timecapsulearchive.core.domain.capsuleskin.data.dto.CapsuleSkinSummaryDto;
 
-@Repository
-@RequiredArgsConstructor
-public class CapsuleSkinQueryRepository {
+public interface CapsuleSkinQueryRepository {
 
-    private final JPAQueryFactory jpaQueryFactory;
-
-    public Slice<CapsuleSkinSummaryDto> findCapsuleSkinSliceByCreatedAtAndMemberId(
+    Slice<CapsuleSkinSummaryDto> findCapsuleSkinSliceByCreatedAtAndMemberId(
         final Long memberId,
         final int size,
         final ZonedDateTime createdAt
-    ) {
-        final List<CapsuleSkinSummaryDto> capsuleSkins = findCapsuleSkinSummaryDtosByCreatedAtAndMemberId(
-            memberId,
-            size,
-            createdAt
-        );
-
-        final boolean hasNext = canMoreRead(size, capsuleSkins.size());
-        if (hasNext) {
-            capsuleSkins.remove(size);
-        }
-
-        return new SliceImpl<>(capsuleSkins, Pageable.ofSize(size), hasNext);
-    }
-
-    private List<CapsuleSkinSummaryDto> findCapsuleSkinSummaryDtosByCreatedAtAndMemberId(
-        final Long memberId,
-        final int size,
-        final ZonedDateTime createdAt
-    ) {
-        return jpaQueryFactory
-            .select(
-                Projections.constructor(
-                    CapsuleSkinSummaryDto.class,
-                    capsuleSkin.id,
-                    capsuleSkin.imageUrl,
-                    capsuleSkin.skinName,
-                    capsuleSkin.createdAt
-                )
-            )
-            .from(capsuleSkin)
-            .where(capsuleSkin.member.id.eq(memberId).and(capsuleSkin.createdAt.lt(createdAt)))
-            .orderBy(capsuleSkin.id.desc())
-            .limit(size + 1)
-            .fetch();
-    }
-
-    private boolean canMoreRead(
-        final int size,
-        final int capsuleSize
-    ) {
-        return capsuleSize > size;
-    }
+    );
 }

--- a/backend/core/src/main/java/site/timecapsulearchive/core/domain/capsuleskin/repository/CapsuleSkinQueryRepository.java
+++ b/backend/core/src/main/java/site/timecapsulearchive/core/domain/capsuleskin/repository/CapsuleSkinQueryRepository.java
@@ -11,4 +11,6 @@ public interface CapsuleSkinQueryRepository {
         final int size,
         final ZonedDateTime createdAt
     );
+
+    boolean existByImageUrlAndMemberId(String imageUrl, Long memberId);
 }

--- a/backend/core/src/main/java/site/timecapsulearchive/core/domain/capsuleskin/repository/CapsuleSkinQueryRepositoryImpl.java
+++ b/backend/core/src/main/java/site/timecapsulearchive/core/domain/capsuleskin/repository/CapsuleSkinQueryRepositoryImpl.java
@@ -43,4 +43,15 @@ public class CapsuleSkinQueryRepositoryImpl implements CapsuleSkinQueryRepositor
 
         return SliceUtil.makeSlice(size, capsuleSkins);
     }
+
+    @Override
+    public boolean existByImageUrlAndMemberId(String imageUrl, Long memberId) {
+        Integer count = jpaQueryFactory
+            .selectOne()
+            .from(capsuleSkin)
+            .where(capsuleSkin.imageUrl.eq(imageUrl).and(capsuleSkin.member.id.eq(memberId)))
+            .fetchOne();
+
+        return count != null;
+    }
 }

--- a/backend/core/src/main/java/site/timecapsulearchive/core/domain/capsuleskin/repository/CapsuleSkinQueryRepositoryImpl.java
+++ b/backend/core/src/main/java/site/timecapsulearchive/core/domain/capsuleskin/repository/CapsuleSkinQueryRepositoryImpl.java
@@ -1,0 +1,46 @@
+package site.timecapsulearchive.core.domain.capsuleskin.repository;
+
+import static site.timecapsulearchive.core.domain.capsuleskin.entity.QCapsuleSkin.capsuleSkin;
+
+import com.querydsl.core.types.Projections;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.time.ZonedDateTime;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.SliceImpl;
+import org.springframework.stereotype.Repository;
+import site.timecapsulearchive.core.domain.capsuleskin.data.dto.CapsuleSkinSummaryDto;
+import site.timecapsulearchive.core.global.util.SliceUtil;
+
+@Repository
+@RequiredArgsConstructor
+public class CapsuleSkinQueryRepositoryImpl implements CapsuleSkinQueryRepository {
+
+    private final JPAQueryFactory jpaQueryFactory;
+
+    public Slice<CapsuleSkinSummaryDto> findCapsuleSkinSliceByCreatedAtAndMemberId(
+        final Long memberId,
+        final int size,
+        final ZonedDateTime createdAt
+    ) {
+        final List<CapsuleSkinSummaryDto> capsuleSkins = jpaQueryFactory
+            .select(
+                Projections.constructor(
+                    CapsuleSkinSummaryDto.class,
+                    capsuleSkin.id,
+                    capsuleSkin.imageUrl,
+                    capsuleSkin.skinName,
+                    capsuleSkin.createdAt
+                )
+            )
+            .from(capsuleSkin)
+            .where(capsuleSkin.member.id.eq(memberId).and(capsuleSkin.createdAt.lt(createdAt)))
+            .orderBy(capsuleSkin.id.desc())
+            .limit(size + 1)
+            .fetch();
+
+        return SliceUtil.makeSlice(size, capsuleSkins);
+    }
+}

--- a/backend/core/src/main/java/site/timecapsulearchive/core/domain/capsuleskin/repository/CapsuleSkinRepository.java
+++ b/backend/core/src/main/java/site/timecapsulearchive/core/domain/capsuleskin/repository/CapsuleSkinRepository.java
@@ -8,7 +8,8 @@ import org.springframework.data.repository.Repository;
 import org.springframework.data.repository.query.Param;
 import site.timecapsulearchive.core.domain.capsuleskin.entity.CapsuleSkin;
 
-public interface CapsuleSkinRepository extends Repository<CapsuleSkin, Long> {
+public interface CapsuleSkinRepository extends Repository<CapsuleSkin, Long>,
+    CapsuleSkinQueryRepository {
 
     Optional<CapsuleSkin> save(CapsuleSkin capsuleSkin);
 

--- a/backend/core/src/main/java/site/timecapsulearchive/core/domain/capsuleskin/service/CapsuleSkinService.java
+++ b/backend/core/src/main/java/site/timecapsulearchive/core/domain/capsuleskin/service/CapsuleSkinService.java
@@ -14,7 +14,6 @@ import site.timecapsulearchive.core.domain.capsuleskin.data.response.CapsuleSkin
 import site.timecapsulearchive.core.domain.capsuleskin.data.response.CapsuleSkinsSliceResponse;
 import site.timecapsulearchive.core.domain.capsuleskin.entity.CapsuleSkin;
 import site.timecapsulearchive.core.domain.capsuleskin.exception.CapsuleSkinNotFoundException;
-import site.timecapsulearchive.core.domain.capsuleskin.repository.CapsuleSkinQueryRepository;
 import site.timecapsulearchive.core.domain.capsuleskin.repository.CapsuleSkinRepository;
 import site.timecapsulearchive.core.domain.member.entity.Member;
 import site.timecapsulearchive.core.domain.member.exception.MemberNotFoundException;
@@ -26,7 +25,6 @@ import site.timecapsulearchive.core.infra.queue.manager.CapsuleSkinMessageManage
 public class CapsuleSkinService {
 
     private final CapsuleSkinRepository capsuleSkinRepository;
-    private final CapsuleSkinQueryRepository capsuleSkinQueryRepository;
     private final CapsuleSkinMessageManager capsuleSkinMessageManager;
     private final MemberRepository memberRepository;
     private final CapsuleSkinMapper capsuleSkinMapper;
@@ -38,7 +36,7 @@ public class CapsuleSkinService {
         final int size,
         final ZonedDateTime createdAt
     ) {
-        final Slice<CapsuleSkinSummaryDto> slice = capsuleSkinQueryRepository.findCapsuleSkinSliceByCreatedAtAndMemberId(
+        final Slice<CapsuleSkinSummaryDto> slice = capsuleSkinRepository.findCapsuleSkinSliceByCreatedAtAndMemberId(
             memberId,
             size,
             createdAt


### PR DESCRIPTION
## 작업 내용 (Content)
- 보물 캡슐 중복 수령 시 캡슐 스킨 저장하지 않고 프론트에 상태 값 반환

## 링크 (Links)
- #534

## 기타 사항 (Etc)

## Merge 전 필요 작업 (Checklist before merge)

## 희망 리뷰 완료 일 (Expected due date)
