### PR TITLE
refact : 그룹 캡슐 디테일 오류 수정 및 쿼리 가독성 개선 #546

### DIFF
--- a/backend/core/src/main/java/site/timecapsulearchive/core/domain/capsule/group_capsule/api/GroupCapsuleApiController.java
+++ b/backend/core/src/main/java/site/timecapsulearchive/core/domain/capsule/group_capsule/api/GroupCapsuleApiController.java
@@ -78,8 +78,7 @@ public class GroupCapsuleApiController implements GroupCapsuleApi {
         return ResponseEntity.ok(
             ApiSpec.success(
                 SuccessCode.SUCCESS,
-                GroupCapsuleDetailResponse.createOf(
-                    detailDto,
+                detailDto.toResponse(
                     s3PreSignedUrlManager::getS3PreSignedUrlForGet,
                     s3PreSignedUrlManager::getS3PreSignedUrlsForGet,
                     geoTransformManager::changePoint3857To4326

--- a/backend/core/src/main/java/site/timecapsulearchive/core/domain/capsule/group_capsule/data/dto/GroupCapsuleDetailDto.java
+++ b/backend/core/src/main/java/site/timecapsulearchive/core/domain/capsule/group_capsule/data/dto/GroupCapsuleDetailDto.java
@@ -2,6 +2,7 @@ package site.timecapsulearchive.core.domain.capsule.group_capsule.data.dto;
 
 import java.util.List;
 import java.util.function.Function;
+import java.util.function.UnaryOperator;
 import org.locationtech.jts.geom.Point;
 import site.timecapsulearchive.core.domain.capsule.generic_capsule.data.dto.CapsuleDetailDto;
 import site.timecapsulearchive.core.domain.capsule.group_capsule.data.response.GroupCapsuleDetailResponse;
@@ -9,11 +10,11 @@ import site.timecapsulearchive.core.domain.capsule.group_capsule.data.response.G
 
 public record GroupCapsuleDetailDto(
     CapsuleDetailDto capsuleDetailDto,
-    List<GroupCapsuleMemberSummaryDto> members
+    List<GroupCapsuleMemberSummaryDto> groupMembers
 ) {
 
     public List<GroupCapsuleMemberSummaryResponse> groupMemberSummaryDtoToResponse() {
-        return members.stream()
+        return groupMembers.stream()
             .map(GroupCapsuleMemberSummaryDto::toResponse)
             .toList();
     }
@@ -21,16 +22,16 @@ public record GroupCapsuleDetailDto(
     public GroupCapsuleDetailDto excludeDetailContents() {
         return new GroupCapsuleDetailDto(
             capsuleDetailDto.excludeTitleAndContentAndImagesAndVideos(),
-            members
+            groupMembers
         );
     }
 
     public GroupCapsuleDetailResponse toResponse(
-        final Function<String, String> singlePreSignUrlFunction,
+        final UnaryOperator<String> singlePreSignUrlFunction,
         final Function<String, List<String>> multiplePreSignUrlFunction,
-        final Function<Point, Point> changePointFunction
+        final UnaryOperator<Point> pointTransformFunction
     ) {
-        final Point changePoint = changePointFunction.apply(capsuleDetailDto.point());
+        final Point changePoint = pointTransformFunction.apply(capsuleDetailDto.point());
 
         final List<String> preSignedImageUrls = multiplePreSignUrlFunction.apply(
             capsuleDetailDto.images());
@@ -40,16 +41,16 @@ public record GroupCapsuleDetailDto(
         return GroupCapsuleDetailResponse.builder()
             .capsuleId(capsuleDetailDto.capsuleId())
             .capsuleSkinUrl(singlePreSignUrlFunction.apply(capsuleDetailDto.capsuleSkinUrl()))
-            .members(groupMemberSummaryDtoToResponse())
+            .groupMembers(groupMemberSummaryDtoToResponse())
             .dueDate(capsuleDetailDto.dueDate())
-            .nickname(capsuleDetailDto.nickname())
-            .profileUrl(capsuleDetailDto.profileUrl())
-            .createdDate(capsuleDetailDto.createdAt())
+            .creatorNickname(capsuleDetailDto.nickname())
+            .creatorProfileUrl(capsuleDetailDto.profileUrl())
+            .createdAt(capsuleDetailDto.createdAt())
             .latitude(changePoint.getX())
             .longitude(changePoint.getY())
             .address(capsuleDetailDto.address())
-            .roadName(capsuleDetailDto().roadName())
-            .title(capsuleDetailDto().title())
+            .roadName(capsuleDetailDto.roadName())
+            .title(capsuleDetailDto.title())
             .content(capsuleDetailDto.content())
             .imageUrls(preSignedImageUrls)
             .videoUrls(preSignedVideoUrls)

--- a/backend/core/src/main/java/site/timecapsulearchive/core/domain/capsule/group_capsule/data/response/GroupCapsuleDetailResponse.java
+++ b/backend/core/src/main/java/site/timecapsulearchive/core/domain/capsule/group_capsule/data/response/GroupCapsuleDetailResponse.java
@@ -3,11 +3,8 @@ package site.timecapsulearchive.core.domain.capsule.group_capsule.data.response;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.ZonedDateTime;
 import java.util.List;
-import java.util.function.Function;
 import lombok.Builder;
-import org.locationtech.jts.geom.Point;
 import site.timecapsulearchive.core.domain.capsule.entity.CapsuleType;
-import site.timecapsulearchive.core.domain.capsule.group_capsule.data.dto.GroupCapsuleDetailDto;
 import site.timecapsulearchive.core.global.common.response.ResponseMappingConstant;
 
 @Schema(description = "그룹 캡슐 상세 정보")
@@ -21,19 +18,19 @@ public record GroupCapsuleDetailResponse(
     String capsuleSkinUrl,
 
     @Schema(description = "그룹원 요약 정보")
-    List<GroupCapsuleMemberSummaryResponse> members,
+    List<GroupCapsuleMemberSummaryResponse> groupMembers,
 
     @Schema(description = "개봉일")
     ZonedDateTime dueDate,
 
     @Schema(description = "생성자 닉네임")
-    String nickname,
+    String creatorNickname,
 
     @Schema(description = "생성자 프로필 url")
-    String profileUrl,
+    String creatorProfileUrl,
 
     @Schema(description = "생성일")
-    ZonedDateTime createdDate,
+    ZonedDateTime createdAt,
 
     @Schema(description = "캡슐 위도 좌표")
     Double latitude,
@@ -71,17 +68,6 @@ public record GroupCapsuleDetailResponse(
             dueDate = dueDate.withZoneSameInstant(ResponseMappingConstant.ZONE_ID);
         }
 
-        createdDate.withZoneSameInstant(ResponseMappingConstant.ZONE_ID);
+        createdAt = createdAt.withZoneSameInstant(ResponseMappingConstant.ZONE_ID);
     }
-
-    public static GroupCapsuleDetailResponse createOf(
-        final GroupCapsuleDetailDto groupCapsuleDetailDto,
-        final Function<String, String> singlePreSignUrlFunction,
-        final Function<String, List<String>> multiplePreSignUrlFunction,
-        final Function<Point, Point> changePointFunction
-    ) {
-        return groupCapsuleDetailDto.toResponse(singlePreSignUrlFunction,
-            multiplePreSignUrlFunction, changePointFunction);
-    }
-
 }

--- a/backend/core/src/main/java/site/timecapsulearchive/core/domain/capsule/group_capsule/repository/GroupCapsuleQueryRepository.java
+++ b/backend/core/src/main/java/site/timecapsulearchive/core/domain/capsule/group_capsule/repository/GroupCapsuleQueryRepository.java
@@ -43,47 +43,48 @@ public class GroupCapsuleQueryRepository {
         final QMember owner = new QMember("owner");
         final QMember groupMember = new QMember("groupMember");
 
-        return Optional.ofNullable(jpaQueryFactory
-            .selectFrom(capsule)
-            .join(owner).on(capsule.member.id.eq(owner.id))
-            .join(capsuleSkin).on(capsule.capsuleSkin.id.eq(capsuleSkin.id))
-            .leftJoin(image).on(capsule.id.eq(image.capsule.id))
-            .leftJoin(video).on(capsule.id.eq(video.capsule.id))
-            .join(groupCapsuleOpen).on(groupCapsuleOpen.capsule.id.eq(capsuleId))
-            .join(groupMember).on(groupMember.id.eq(groupCapsuleOpen.member.id))
-            .groupBy(groupCapsuleOpen.id)
-            .where(groupCapsuleOpen.capsule.id.eq(capsuleId))
-            .where(capsule.id.eq(capsuleId).and(capsule.type.eq(CapsuleType.GROUP)))
-            .transform(
-                groupBy(capsule.id).as(
-                    Projections.constructor(
-                        GroupCapsuleDetailDto.class,
+        return Optional.ofNullable(
+            jpaQueryFactory
+                .selectFrom(capsule)
+                .join(capsule.member, owner)
+                .join(capsule.capsuleSkin, capsuleSkin)
+                .leftJoin(image).on(capsule.id.eq(image.capsule.id))
+                .leftJoin(video).on(capsule.id.eq(video.capsule.id))
+                .join(groupCapsuleOpen).on(groupCapsuleOpen.capsule.id.eq(capsule.id))
+                .join(groupMember).on(groupMember.id.eq(groupCapsuleOpen.member.id))
+                .where(groupCapsuleOpen.capsule.id.eq(capsuleId).and(capsule.id.eq(capsuleId))
+                    .and(capsule.type.eq(CapsuleType.GROUP)))
+                .groupBy(groupCapsuleOpen.id)
+                .transform(
+                    groupBy(capsule.id).as(
                         Projections.constructor(
-                            CapsuleDetailDto.class,
-                            capsule.id,
-                            capsuleSkin.imageUrl,
-                            capsule.dueDate,
-                            owner.nickname,
-                            owner.profileUrl,
-                            capsule.createdAt,
-                            capsule.point,
-                            capsule.address.fullRoadAddressName,
-                            capsule.address.roadName,
-                            capsule.title,
-                            capsule.content,
-                            groupConcatDistinct(image.imageUrl),
-                            groupConcatDistinct(video.videoUrl),
-                            capsule.isOpened,
-                            capsule.type
-                        ),
-                        list(Projections.constructor(GroupCapsuleMemberSummaryDto.class,
-                            groupMember.nickname,
-                            groupMember.profileUrl,
-                            groupCapsuleOpen.isOpened)
+                            GroupCapsuleDetailDto.class,
+                            Projections.constructor(
+                                CapsuleDetailDto.class,
+                                capsule.id,
+                                capsuleSkin.imageUrl,
+                                capsule.dueDate,
+                                owner.nickname,
+                                owner.profileUrl,
+                                capsule.createdAt,
+                                capsule.point,
+                                capsule.address.fullRoadAddressName,
+                                capsule.address.roadName,
+                                capsule.title,
+                                capsule.content,
+                                groupConcatDistinct(image.imageUrl),
+                                groupConcatDistinct(video.videoUrl),
+                                capsule.isOpened,
+                                capsule.type
+                            ),
+                            list(Projections.constructor(GroupCapsuleMemberSummaryDto.class,
+                                groupMember.nickname,
+                                groupMember.profileUrl,
+                                groupCapsuleOpen.isOpened)
+                            )
                         )
                     )
-                )
-            ).get(capsuleId));
+                ).get(capsuleId));
     }
 
     private StringExpression groupConcatDistinct(final StringExpression expression) {

--- a/backend/core/src/test/java/site/timecapsulearchive/core/domain/capsule/group_capsule/repository/GroupCapsuleQueryRepositoryTest.java
+++ b/backend/core/src/test/java/site/timecapsulearchive/core/domain/capsule/group_capsule/repository/GroupCapsuleQueryRepositoryTest.java
@@ -115,7 +115,7 @@ class GroupCapsuleQueryRepositoryTest extends RepositoryTest {
         //when
         GroupCapsuleDetailDto detailDto = groupCapsuleQueryRepository.findGroupCapsuleDetailDtoByCapsuleId(
             capsule.getId()).orElseThrow();
-        List<GroupCapsuleMemberSummaryDto> summaryDto = detailDto.members();
+        List<GroupCapsuleMemberSummaryDto> summaryDto = detailDto.groupMembers();
 
         //then
         assertSoftly(

--- a/backend/core/src/test/java/site/timecapsulearchive/core/domain/capsule/group_capsule/service/GroupCapsuleServiceTest.java
+++ b/backend/core/src/test/java/site/timecapsulearchive/core/domain/capsule/group_capsule/service/GroupCapsuleServiceTest.java
@@ -77,7 +77,7 @@ class GroupCapsuleServiceTest {
         //then
         assertSoftly(softly -> {
             CapsuleDetailDto detailDto = response.capsuleDetailDto();
-            List<GroupCapsuleMemberSummaryDto> members = response.members();
+            List<GroupCapsuleMemberSummaryDto> members = response.groupMembers();
             softly.assertThat(response).isNotNull();
             softly.assertThat(detailDto.isOpened()).isTrue();
             softly.assertThat(detailDto.title()).isNotBlank();
@@ -103,7 +103,7 @@ class GroupCapsuleServiceTest {
         //then
         assertSoftly(softly -> {
             CapsuleDetailDto detailDto = response.capsuleDetailDto();
-            List<GroupCapsuleMemberSummaryDto> members = response.members();
+            List<GroupCapsuleMemberSummaryDto> members = response.groupMembers();
             softly.assertThat(response).isNotNull();
             softly.assertThat(detailDto.isOpened()).isTrue();
             softly.assertThat(detailDto.title()).isNotBlank();
@@ -129,7 +129,7 @@ class GroupCapsuleServiceTest {
         //then
         assertSoftly(softly -> {
             CapsuleDetailDto detailDto = response.capsuleDetailDto();
-            List<GroupCapsuleMemberSummaryDto> members = response.members();
+            List<GroupCapsuleMemberSummaryDto> members = response.groupMembers();
             softly.assertThat(response).isNotNull();
             softly.assertThat(detailDto.isOpened()).isFalse();
             softly.assertThat(detailDto.title()).isNotBlank();
@@ -156,7 +156,7 @@ class GroupCapsuleServiceTest {
         //then
         assertSoftly(softly -> {
             CapsuleDetailDto detailDto = response.capsuleDetailDto();
-            List<GroupCapsuleMemberSummaryDto> members = response.members();
+            List<GroupCapsuleMemberSummaryDto> members = response.groupMembers();
             softly.assertThat(response).isNotNull();
             softly.assertThat(detailDto.isOpened()).isFalse();
             softly.assertThat(detailDto.images()).isNullOrEmpty();
@@ -181,7 +181,7 @@ class GroupCapsuleServiceTest {
         //then
         assertSoftly(softly -> {
             CapsuleDetailDto detailDto = response.capsuleDetailDto();
-            List<GroupCapsuleMemberSummaryDto> members = response.members();
+            List<GroupCapsuleMemberSummaryDto> members = response.groupMembers();
             softly.assertThat(response).isNotNull();
             softly.assertThat(detailDto.isOpened()).isFalse();
             softly.assertThat(detailDto.images()).isNullOrEmpty();
@@ -206,7 +206,7 @@ class GroupCapsuleServiceTest {
         //then
         assertSoftly(softly -> {
             CapsuleDetailDto detailDto = response.capsuleDetailDto();
-            List<GroupCapsuleMemberSummaryDto> members = response.members();
+            List<GroupCapsuleMemberSummaryDto> members = response.groupMembers();
             softly.assertThat(response).isNotNull();
             softly.assertThat(detailDto.isOpened()).isTrue();
             softly.assertThat(detailDto.images()).isNullOrEmpty();


### PR DESCRIPTION
## 작업 내용 (Content)
- createdAt 필드에 시간 변환이 들어가지 않았던 오류 수정
- 반환 필드 이름 명확하게 creator 붙여서 수정
- 쿼리 가독성 개선

## 링크 (Links)
- #546 

## 기타 사항 (Etc)

## Merge 전 필요 작업 (Checklist before merge)

## 희망 리뷰 완료 일 (Expected due date)
