### PR TITLE
fix : 데이터베이스 유니크 중복 예외 처리 

### DIFF
--- a/backend/core/src/main/java/site/timecapsulearchive/core/domain/auth/service/MessageVerificationService.java
+++ b/backend/core/src/main/java/site/timecapsulearchive/core/domain/auth/service/MessageVerificationService.java
@@ -4,6 +4,7 @@ import java.nio.charset.StandardCharsets;
 import java.security.SecureRandom;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import site.timecapsulearchive.core.domain.auth.data.dto.VerificationMessageSendDto;
@@ -13,6 +14,7 @@ import site.timecapsulearchive.core.domain.auth.repository.MessageAuthentication
 import site.timecapsulearchive.core.domain.member.entity.Member;
 import site.timecapsulearchive.core.domain.member.entity.MemberTemporary;
 import site.timecapsulearchive.core.domain.member.exception.MemberNotFoundException;
+import site.timecapsulearchive.core.domain.member.exception.MemberUpdateDataException;
 import site.timecapsulearchive.core.domain.member.repository.MemberRepository;
 import site.timecapsulearchive.core.domain.member.repository.MemberTemporaryRepository;
 import site.timecapsulearchive.core.global.security.encryption.AESEncryptionManager;
@@ -118,7 +120,11 @@ public class MessageVerificationService {
         final Member verifiedMember = memberTemporary.toMember(hashEncryptionManager.encrypt(plain),
             aesEncryptionManager.encryptWithPrefixIV(plain));
 
-        memberRepository.save(verifiedMember);
+        try {
+            memberRepository.saveAndFlush(verifiedMember);
+        } catch (DataIntegrityViolationException e) {
+            throw new MemberUpdateDataException();
+        }
 
         return verifiedMember.getId();
     }

--- a/backend/core/src/main/java/site/timecapsulearchive/core/domain/auth/service/MessageVerificationService.java
+++ b/backend/core/src/main/java/site/timecapsulearchive/core/domain/auth/service/MessageVerificationService.java
@@ -14,7 +14,7 @@ import site.timecapsulearchive.core.domain.auth.repository.MessageAuthentication
 import site.timecapsulearchive.core.domain.member.entity.Member;
 import site.timecapsulearchive.core.domain.member.entity.MemberTemporary;
 import site.timecapsulearchive.core.domain.member.exception.MemberNotFoundException;
-import site.timecapsulearchive.core.domain.member.exception.MemberUpdateDataException;
+import site.timecapsulearchive.core.domain.member.exception.MemberTagDuplicatedException;
 import site.timecapsulearchive.core.domain.member.repository.MemberRepository;
 import site.timecapsulearchive.core.domain.member.repository.MemberTemporaryRepository;
 import site.timecapsulearchive.core.global.security.encryption.AESEncryptionManager;
@@ -123,7 +123,7 @@ public class MessageVerificationService {
         try {
             memberRepository.saveAndFlush(verifiedMember);
         } catch (DataIntegrityViolationException e) {
-            throw new MemberUpdateDataException();
+            throw new MemberTagDuplicatedException();
         }
 
         return verifiedMember.getId();

--- a/backend/core/src/main/java/site/timecapsulearchive/core/domain/member/entity/Member.java
+++ b/backend/core/src/main/java/site/timecapsulearchive/core/domain/member/entity/Member.java
@@ -89,4 +89,9 @@ public class Member extends BaseEntity {
     public void updateTagLowerCaseSocialType() {
         this.tag = TagGenerator.lowercase(email, socialType);
     }
+
+    public void updateData(String nickname, String tag) {
+        this.nickname = nickname;
+        this.tag = tag;
+    }
 }

--- a/backend/core/src/main/java/site/timecapsulearchive/core/domain/member/exception/MemberTagDuplicatedException.java
+++ b/backend/core/src/main/java/site/timecapsulearchive/core/domain/member/exception/MemberTagDuplicatedException.java
@@ -3,9 +3,9 @@ package site.timecapsulearchive.core.domain.member.exception;
 import site.timecapsulearchive.core.global.error.ErrorCode;
 import site.timecapsulearchive.core.global.error.exception.BusinessException;
 
-public class MemberUpdateDataException extends BusinessException {
+public class MemberTagDuplicatedException extends BusinessException {
 
-    public MemberUpdateDataException() {
-        super(ErrorCode.MEMBER_UPDATE_DATA_ERROR);
+    public MemberTagDuplicatedException() {
+        super(ErrorCode.MEMBER_TAG_DUPLICATED_ERROR);
     }
 }

--- a/backend/core/src/main/java/site/timecapsulearchive/core/domain/member/exception/MemberUpdateDataException.java
+++ b/backend/core/src/main/java/site/timecapsulearchive/core/domain/member/exception/MemberUpdateDataException.java
@@ -1,0 +1,11 @@
+package site.timecapsulearchive.core.domain.member.exception;
+
+import site.timecapsulearchive.core.global.error.ErrorCode;
+import site.timecapsulearchive.core.global.error.exception.BusinessException;
+
+public class MemberUpdateDataException extends BusinessException {
+
+    public MemberUpdateDataException() {
+        super(ErrorCode.MEMBER_UPDATE_DATA_ERROR);
+    }
+}

--- a/backend/core/src/main/java/site/timecapsulearchive/core/domain/member/repository/MemberRepository.java
+++ b/backend/core/src/main/java/site/timecapsulearchive/core/domain/member/repository/MemberRepository.java
@@ -14,6 +14,8 @@ public interface MemberRepository extends Repository<Member, Long>, MemberQueryR
 
     Member save(Member createMember);
 
+    void saveAndFlush(Member member);
+
     Optional<Member> findMemberById(Long memberId);
 
     @Modifying(clearAutomatically = true)

--- a/backend/core/src/main/java/site/timecapsulearchive/core/domain/member/service/MemberService.java
+++ b/backend/core/src/main/java/site/timecapsulearchive/core/domain/member/service/MemberService.java
@@ -16,7 +16,7 @@ import site.timecapsulearchive.core.domain.member.entity.MemberTemporary;
 import site.timecapsulearchive.core.domain.member.entity.SocialType;
 import site.timecapsulearchive.core.domain.member.exception.AlreadyVerifiedException;
 import site.timecapsulearchive.core.domain.member.exception.MemberNotFoundException;
-import site.timecapsulearchive.core.domain.member.exception.MemberUpdateDataException;
+import site.timecapsulearchive.core.domain.member.exception.MemberTagDuplicatedException;
 import site.timecapsulearchive.core.domain.member.exception.NotVerifiedMemberException;
 import site.timecapsulearchive.core.domain.member.repository.MemberRepository;
 import site.timecapsulearchive.core.domain.member.repository.MemberTemporaryRepository;
@@ -161,7 +161,7 @@ public class MemberService {
         try {
             memberRepository.saveAndFlush(member);
         } catch (DataIntegrityViolationException e) {
-            throw new MemberUpdateDataException();
+            throw new MemberTagDuplicatedException();
         }
 
     }

--- a/backend/core/src/main/java/site/timecapsulearchive/core/domain/member/service/MemberService.java
+++ b/backend/core/src/main/java/site/timecapsulearchive/core/domain/member/service/MemberService.java
@@ -2,6 +2,7 @@ package site.timecapsulearchive.core.domain.member.service;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import site.timecapsulearchive.core.domain.member.data.dto.MemberDetailDto;
@@ -15,6 +16,7 @@ import site.timecapsulearchive.core.domain.member.entity.MemberTemporary;
 import site.timecapsulearchive.core.domain.member.entity.SocialType;
 import site.timecapsulearchive.core.domain.member.exception.AlreadyVerifiedException;
 import site.timecapsulearchive.core.domain.member.exception.MemberNotFoundException;
+import site.timecapsulearchive.core.domain.member.exception.MemberUpdateDataException;
 import site.timecapsulearchive.core.domain.member.exception.NotVerifiedMemberException;
 import site.timecapsulearchive.core.domain.member.repository.MemberRepository;
 import site.timecapsulearchive.core.domain.member.repository.MemberTemporaryRepository;
@@ -153,12 +155,15 @@ public class MemberService {
         final Long memberId,
         final UpdateMemberDataDto updateMemberDataDto
     ) {
-        final int updateMemberData = memberRepository.updateMemberData(memberId,
-            updateMemberDataDto.nickname(), updateMemberDataDto.tag());
+        final Member member = memberRepository.findMemberById(memberId).orElseThrow(MemberNotFoundException::new);
 
-        if (updateMemberData != 1) {
-            throw new MemberNotFoundException();
+        member.updateData(updateMemberDataDto.nickname(), updateMemberDataDto.tag());
+        try {
+            memberRepository.saveAndFlush(member);
+        } catch (DataIntegrityViolationException e) {
+            throw new MemberUpdateDataException();
         }
+
     }
 
     @Transactional

--- a/backend/core/src/main/java/site/timecapsulearchive/core/global/error/ErrorCode.java
+++ b/backend/core/src/main/java/site/timecapsulearchive/core/global/error/ErrorCode.java
@@ -47,7 +47,7 @@ public enum ErrorCode {
 
     MEMBER_NOT_FOUND_ERROR(404, "MEMBER-003", "사용자 데이터를 찾지 못하였습니다."),
 
-    MEMBER_UPDATE_DATA_ERROR(400, "MEMBER-004", "사용자 정보 수정에 실패 하였습니다."),
+    MEMBER_TAG_DUPLICATED_ERROR(400, "MEMBER-004", "사용자의 태그가 중복 되었습니다."),
 
     //geo
     GEO_TRANSFORMED_ERROR(400, "GEO-001", "좌표 변환에 실패했습니다. 입력이 유효한지 확인해주세요"),

--- a/backend/core/src/main/java/site/timecapsulearchive/core/global/error/ErrorCode.java
+++ b/backend/core/src/main/java/site/timecapsulearchive/core/global/error/ErrorCode.java
@@ -47,6 +47,8 @@ public enum ErrorCode {
 
     MEMBER_NOT_FOUND_ERROR(404, "MEMBER-003", "사용자 데이터를 찾지 못하였습니다."),
 
+    MEMBER_UPDATE_DATA_ERROR(400, "MEMBER-004", "사용자 정보 수정에 실패 하였습니다."),
+
     //geo
     GEO_TRANSFORMED_ERROR(400, "GEO-001", "좌표 변환에 실패했습니다. 입력이 유효한지 확인해주세요"),
 

--- a/backend/core/src/test/java/site/timecapsulearchive/core/domain/auth/service/MessageVerificationServiceTest.java
+++ b/backend/core/src/test/java/site/timecapsulearchive/core/domain/auth/service/MessageVerificationServiceTest.java
@@ -81,44 +81,4 @@ class MessageVerificationServiceTest {
             .isInstanceOf(CertificationNumberNotMatchException.class);
     }
 
-    @Test
-    void 인증번호가_일치하면_사용자를_저장한다() {
-        //given
-        String certificationNumber = "1234";
-        given(messageAuthenticationCacheRepository.findMessageAuthenticationCodeByMemberId(
-            anyLong(), any()))
-            .willReturn(Optional.of(certificationNumber));
-        given(memberTemporaryRepository.findById(anyLong()))
-            .willReturn(Optional.of(MemberTemporaryFixture.memberTemporary(MEMBER_ID)));
-        given(memberRepository.checkTagDuplication(any())).willReturn(false);
-
-        //when
-        messageVerificationService.validVerificationMessage(MEMBER_ID, certificationNumber,
-            RECEIVER);
-
-        //then
-        verify(memberRepository, times(1)).saveAndFlush(any(Member.class));
-    }
-
-    @Test
-    void 태그가_중복되면_태그를_교체한다() {
-        //given
-        String certificationNumber = "1234";
-        MemberTemporary memberTemporary = MemberTemporaryFixture.memberTemporary(MEMBER_ID);
-        String originTag = memberTemporary.getTag();
-        given(messageAuthenticationCacheRepository.findMessageAuthenticationCodeByMemberId(
-            anyLong(), any()))
-            .willReturn(Optional.of(certificationNumber));
-        given(memberTemporaryRepository.findById(anyLong()))
-            .willReturn(Optional.of(memberTemporary));
-        given(memberRepository.checkTagDuplication(any())).willReturn(true);
-
-        //when
-        messageVerificationService.validVerificationMessage(MEMBER_ID, certificationNumber,
-            RECEIVER);
-
-        //then
-        assertThat(memberTemporary.getTag()).isNotEqualTo(originTag);
-    }
-
 }

--- a/backend/core/src/test/java/site/timecapsulearchive/core/domain/auth/service/MessageVerificationServiceTest.java
+++ b/backend/core/src/test/java/site/timecapsulearchive/core/domain/auth/service/MessageVerificationServiceTest.java
@@ -102,7 +102,7 @@ class MessageVerificationServiceTest {
             RECEIVER);
 
         //then
-        verify(memberRepository, times(1)).save(any(Member.class));
+        verify(memberRepository, times(1)).saveAndFlush(any(Member.class));
     }
 
     @Test


### PR DESCRIPTION
## 작업 내용 (Content)
- 데이터베이스 Unique 제약조건 예외 처리
## 링크 (Links)

- [개발 문서](https://taesan94.tistory.com/272)
- [기획 문서](#549 )


## 기타 사항 (Etc)
- 데이터베이스 Unique 제약조건 예외를 Application 단위에서 잡지를 못함 -> 트랜잭션이 이후 DB단에서 예외가 발생하기 때문
- @Transactional을 사용하지 않거나 바로 flush를 하여 예외를 잡는 방법 중 후자를 선택함

## Merge 전 필요 작업 (Checklist before merge)


## 희망 리뷰 완료 일 (Expected due date)
202X. X. X. Wed
