### PR TITLE
fix : 큐로 메시지 전송 시 큐 선언 확인 안하도록 변경 #631

### DIFF
--- a/backend/AnimatedDrawings/application/task/base_task.py
+++ b/backend/AnimatedDrawings/application/task/base_task.py
@@ -44,13 +44,8 @@ class LogErrorsTask(Task):
                                 type='direct',
                                 durable=True)
 
-            notification_queue = Queue(name=QueueConfig.NOTIFICATION_QUEUE_NAME,
-                          exchange=notification_exchange,
-                          routing_key=QueueConfig.NOTIFICATION_QUEUE_NAME)
-
             producer.publish(
                 request_data,
-                declare=[notification_queue],
                 exchange=notification_exchange,
                 content_type='application/json',
                 routing_key=QueueConfig.NOTIFICATION_QUEUE_NAME,

--- a/backend/AnimatedDrawings/application/task/tasks.py
+++ b/backend/AnimatedDrawings/application/task/tasks.py
@@ -119,13 +119,8 @@ def send_notification(self, _, input_data: dict, filename: str):
                             type='direct',
                             durable=True)
 
-        queue = Queue(name=QueueConfig.NOTIFICATION_QUEUE_NAME,
-                      exchange=exchange,
-                      routing_key=QueueConfig.NOTIFICATION_QUEUE_NAME)
-
         producer.publish(
             request_data,
-            declare=[queue],
             exchange=exchange,
             content_type='application/json',
             routing_key=QueueConfig.NOTIFICATION_QUEUE_NAME,


### PR DESCRIPTION
## 작업 내용 (Content)
- 메시지 전송마다 celery가 큐 선언 확인하기에 매 번 옵션을 지정해야해서 `declare `삭제

## 링크 (Links)
- #631

## 기타 사항 (Etc)

## Merge 전 필요 작업 (Checklist before merge)

## 희망 리뷰 완료 일 (Expected due date)
